### PR TITLE
publicPath has nothing to do with the filesystem, så no point in usin…

### DIFF
--- a/webpack.base.config.babel.js
+++ b/webpack.base.config.babel.js
@@ -41,7 +41,7 @@ if (subDir.endsWith('/')) { subDir = subDir.slice(0, -1); }
 
 export const buildDir = path.join('dist', subDir);
 // Webpack needs final slash in publicPath to rewrite relative paths correctly
-const publicPathWithoutSlash = path.join('/', subDir);
+const publicPathWithoutSlash = '/' + subDir;
 export const publicPath = publicPathWithoutSlash + (subDir ? '/' : '');
 export const lessonSrc = '../oppgaver/src';
 const assets = './src/assets';


### PR DESCRIPTION
…g “path”-function, which messes things up on windows.