### PR TITLE
212 filter .html away from links

### DIFF
--- a/src/components/Lesson/Lesson.js
+++ b/src/components/Lesson/Lesson.js
@@ -10,6 +10,7 @@ import processContent from './processContent';
 import contentStyles from './Content.scss';
 import {ImprovePageContainer} from './ImprovePage.js';
 import Row from 'react-bootstrap/lib/Row';
+import {removeHtmlFileEnding} from '../../util.js'
 
 
 const Lesson = React.createClass({
@@ -24,7 +25,7 @@ const Lesson = React.createClass({
   },
   createMarkup(){
     return {
-      __html: this.props.lesson.content
+      __html: removeHtmlFileEnding(this.props.lesson.content)
     };
   },
   componentWillMount(){

--- a/src/components/Lesson/Lesson.js
+++ b/src/components/Lesson/Lesson.js
@@ -10,7 +10,7 @@ import processContent from './processContent';
 import contentStyles from './Content.scss';
 import {ImprovePageContainer} from './ImprovePage.js';
 import Row from 'react-bootstrap/lib/Row';
-import {removeHtmlFileEnding} from '../../util.js'
+import {removeHtmlFileEnding} from '../../util.js';
 
 
 const Lesson = React.createClass({

--- a/src/util.js
+++ b/src/util.js
@@ -178,11 +178,12 @@ export function tagsMatchFilter(lessonTags, filter) {
 }
 
 export function removeHtmlFileEnding(lessonPage) {
-  const regex = /<a href=\"\.\.\/[^\s]*\.html\">/; //RegEx for del av tekst som starter med ../ så hva som helst uten whitespace og slutter med .html 
+  //RegEx for del av tekst som starter med <a href= ../ så hva som helst uten whitespace og slutter med .html">
+  const regex = /<a href=\"\.\.\/[^\s]*\.html\">/;
   let result;
-  while (result = regex.exec(lessonPage)){
-    console.log(result);
-    lessonPage = lessonPage.replace(regex, result[0].replace(".html", ""));
+  while (regex.exec(lessonPage)){
+    result = regex.exec(lessonPage);
+    lessonPage = lessonPage.replace(regex, result[0].replace('.html', ''));
   }
   return lessonPage;
 }

--- a/src/util.js
+++ b/src/util.js
@@ -178,7 +178,8 @@ export function tagsMatchFilter(lessonTags, filter) {
 }
 
 export function removeHtmlFileEnding(lessonPage) {
-  //RegEx for matching part of text that starts with <a href= ../ followed by anything not containing whitespaces, and ends with .html">
+  // RegEx for matching part of text that starts with <a href= ../ followed by anything not containing whitespaces, 
+  // and ends with .html">
   const regex = /<a href=\"\.\.\/[^\s]*\.html\">/;
   let result;
   while (regex.exec(lessonPage)){

--- a/src/util.js
+++ b/src/util.js
@@ -176,3 +176,13 @@ export function tagsMatchFilter(lessonTags, filter) {
 
   return true; // The lessonTags contained all the checked filterTags
 }
+
+export function removeHtmlFileEnding(lessonPage) {
+  const regex = /<a href=\"\.\.\/[^\s]*\.html\">/; //RegEx for del av tekst som starter med ../ så hva som helst uten whitespace og slutter med .html 
+  let result;
+  while (result = regex.exec(lessonPage)){
+    console.log(result);
+    lessonPage = lessonPage.replace(regex, result[0].replace(".html", ""));
+  }
+  return lessonPage;
+}

--- a/src/util.js
+++ b/src/util.js
@@ -178,13 +178,7 @@ export function tagsMatchFilter(lessonTags, filter) {
 }
 
 export function removeHtmlFileEnding(lessonPage) {
-  // RegEx for matching part of text that starts with <a href= ../ followed by anything not containing whitespaces, 
-  // and ends with .html">
-  const regex = /<a href=\"\.\.\/[^\s]*\.html\">/;
-  let result;
-  while (regex.exec(lessonPage)){
-    result = regex.exec(lessonPage);
-    lessonPage = lessonPage.replace(regex, result[0].replace('.html', ''));
-  }
-  return lessonPage;
+  // RegEx for matching and removing parts of text that starts with 
+  // <a href= ../ followed by anything not containing whitespaces, and ends with .html">
+  return lessonPage.replace(/(<a href="\.\.\/[^\s]*)\.html(">)/g, '$1$2');
 }

--- a/src/util.js
+++ b/src/util.js
@@ -178,7 +178,7 @@ export function tagsMatchFilter(lessonTags, filter) {
 }
 
 export function removeHtmlFileEnding(lessonPage) {
-  //RegEx for del av tekst som starter med <a href= ../ så hva som helst uten whitespace og slutter med .html">
+  //RegEx for matching part of text that starts with <a href= ../ followed by anything not containing whitespaces, and ends with .html">
   const regex = /<a href=\"\.\.\/[^\s]*\.html\">/;
   let result;
   while (regex.exec(lessonPage)){

--- a/test/util_spec.js
+++ b/test/util_spec.js
@@ -7,6 +7,7 @@ import {
   fixNonArrayTagList,
   mergeTags,
   tagsMatchFilter,
+  removeHtmlFileEnding,
 } from '../src/util';
 
 describe('util', () => {
@@ -300,6 +301,40 @@ describe('util', () => {
       deepFreeze(tags);
       deepFreeze(filter);
       expect(tagsMatchFilter(tags, filter)).to.equal(false);
+    });
+  });
+
+  describe('removeHtmlFileEnding', () => {
+    it('simple test to see that .html is removed correctly', () => {
+      const testString = '<a href="../stuff.html">“html HTML> .html .html>"</a>';
+      const correctString = '<a href="../stuff">“html HTML> .html .html>"</a>';
+      expect(removeHtmlFileEnding(testString)).to.equal(correctString);
+    });
+
+    it('Returns true if string is unchanged', () => {
+      const testString = '../html"> .html"> ../.html> ../.html"';
+      expect(removeHtmlFileEnding(testString)).to.equal(testString);
+    });
+
+    it('Checks that multiple links are correctly edited', () => {
+      const testString = '<a href="../del_inn_nettsiden/del_inn_nettsiden.html">“Del inn nettsiden"</a>\
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam eleifend sit amet nulla nec consectetur.\
+<a href="../forsvunnet_katt/forsvunnet_katt.html">Forvunnet katt</a>';
+      const correctString = '<a href="../del_inn_nettsiden/del_inn_nettsiden">“Del inn nettsiden"</a>\
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam eleifend sit amet nulla nec consectetur.\
+<a href="../forsvunnet_katt/forsvunnet_katt">Forvunnet katt</a>';
+      expect(removeHtmlFileEnding(testString)).to.equal(correctString);
+    });
+
+    it('Returns true if ".html" ending is removed from string of gibberish', () => {
+      const testString = '<a href="../we/write&some-.,Bull*#¤here+-*and)(-"seIF<>the++?/regEx_will?=)\
+(/&%¤#"!remove"The.,Ending^~correctly,We__æøå_alsoPut&%In__Somehtml_words,likeHtml.or.HTML.html_htmlstuff\
+The_Only.thing.that.should.be&removed*is,the".html".ending.html">“html HTML> .html .html>"</a>';
+
+      const correctString = '<a href="../we/write&some-.,Bull*#¤here+-*and)(-"seIF<>the++?/regEx_will?=)\
+(/&%¤#"!remove"The.,Ending^~correctly,We__æøå_alsoPut&%In__Somehtml_words,likeHtml.or.HTML.html_htmlstuff\
+The_Only.thing.that.should.be&removed*is,the".html".ending">“html HTML> .html .html>"</a>';
+      expect(removeHtmlFileEnding(testString)).to.equal(correctString);
     });
   });
 


### PR DESCRIPTION
Fixes issue #212 ads a function to utils that uses a regex to remove the .html ending for links linking to other lessons on the site. Runs the function in Lesson.js, createMarkup() function.