### PR TITLE
214 veiledning button

### DIFF
--- a/src/components/Lesson/Lesson.js
+++ b/src/components/Lesson/Lesson.js
@@ -99,7 +99,8 @@ const Lesson = React.createClass({
     }
   },
   render() {
-    const instructionBtn = !this.props.isStudentMode ? this.getButton(this.props.path) : null;
+    const instructionBtn = !this.props.isStudentMode || this.isReadme(this.props.path)
+    ? this.getButton(this.props.path) : null;
     return (
       <div className={styles.container}>
         <h1>

--- a/src/components/Lesson/Lesson.js
+++ b/src/components/Lesson/Lesson.js
@@ -45,7 +45,7 @@ const Lesson = React.createClass({
     if(!lessonOrReadme){
       for(let key in lessons){
         if(lessons[key]['readmePath'] === '/' + path){
-          lessonOrReadme = lessons[key]['path'];
+          lessonOrReadme = lessons[key]['external'] === '' ? lessons[key]['path'] : undefined;
         }
       }
     }
@@ -66,7 +66,7 @@ const Lesson = React.createClass({
   },
   setLanguage(){
     const lessonLanguage = this.getLanguage();
-    if(lessonLanguage && lessonLanguage !== this.props.language) {
+    if(lessonLanguage !== '' && lessonLanguage !== this.props.language) {
       this.props.setLanguage(lessonLanguage);
     }
   },

--- a/src/components/Lesson/Lesson.js
+++ b/src/components/Lesson/Lesson.js
@@ -11,22 +11,64 @@ import contentStyles from './Content.scss';
 import {ImprovePageContainer} from './ImprovePage.js';
 import Row from 'react-bootstrap/lib/Row';
 import {removeHtmlFileEnding} from '../../util.js';
+import lessonStyles from '../PlaylistPage/LessonItem.scss';
+import Button from 'react-bootstrap/lib/Button';
+import LinkContainer from 'react-router-bootstrap/lib/LinkContainer';
+import {connect} from 'react-redux';
+import {setModeTeacher, setLanguage} from '../../action_creators';
 
 
 const Lesson = React.createClass({
   getTitle() {
-    return this.props.lesson.frontmatter.title;
+    return this.props.lesson.frontmatter.title ? this.props.lesson.frontmatter.title : '';
   },
   getLevel() {
-    return this.props.lesson.frontmatter.level;
+    return this.props.lesson.frontmatter.level ? this.props.lesson.frontmatter.level : 0;
   },
   getAuthor() {
-    return this.props.lesson.frontmatter.author;
+    return this.props.lesson.frontmatter.author ? this.props.lesson.frontmatter.author : '';
+  },
+  getLanguage() {
+    return this.props.lesson.frontmatter.language ? this.props.lesson.frontmatter.language : '';
   },
   createMarkup(){
     return {
       __html: removeHtmlFileEnding(this.props.lesson.content)
     };
+  },
+  getButton(path){
+    const lessons = this.props.lessons;
+    let lessonOrReadme = typeof(lessons['./' + path + '.md']) !== 'undefined'
+    ? lessons['./' + path + '.md']['readmePath'] : undefined;
+    const buttonText = lessonOrReadme ? 'Til lærerveiledning' : 'Til oppgave';
+
+    if(!lessonOrReadme){
+      for(let key in lessons){
+        if(lessons[key]['readmePath'] === '/' + path){
+          lessonOrReadme = lessons[key]['path'];
+        }
+      }
+    }
+    return (lessonOrReadme ?
+      <LinkContainer to={lessonOrReadme}>
+        <Button componentClass="div" className={lessonStyles.instructionBtn} bsStyle="guide" bsSize="small">
+          {buttonText}
+        </Button>
+      </LinkContainer> : null
+    );
+  },
+  isReadme(path){
+    try{
+      return this.props.readmeContext('./' + path + '.md');
+    }catch(e){
+      return;
+    }
+  },
+  setLanguage(){
+    const lessonLanguage = this.getLanguage();
+    if(lessonLanguage && lessonLanguage !== this.props.language) {
+      this.props.setLanguage(lessonLanguage);
+    }
   },
   componentWillMount(){
     if (typeof document === 'undefined') {
@@ -34,6 +76,11 @@ const Lesson = React.createClass({
       return;
     }
     this.props.lesson.content = processContent(this.props.lesson.content, contentStyles);
+
+    if(this.isReadme(this.props.path)) this.props.setModeTeacher();
+    /*Comment this in when language is implemented
+    Changes the language state to the language defined in the current lesson or readme-file*/
+    //this.setLanguage();
   },
   componentDidMount() {
     const nodes = document.getElementsByClassName('togglebutton');
@@ -52,10 +99,15 @@ const Lesson = React.createClass({
     }
   },
   render() {
+    const instructionBtn = !this.props.isStudentMode ? this.getButton(this.props.path) : null;
     return (
       <div className={styles.container}>
-        <h1><LevelIcon level={this.getLevel()}/>{this.getTitle()} - Level {this.getLevel()}</h1>
-        <p><i>av {this.getAuthor()}</i></p>
+        <h1>
+          <LevelIcon level={this.getLevel()}/>
+          {this.getTitle()}{this.getLevel > 0 ? '- Level ' + this.getLevel() : ''}
+        </h1>
+        {this.getAuthor() !== '' ? <p><i>av {this.getAuthor()}</i></p> : ''}
+        {instructionBtn}
         <div dangerouslySetInnerHTML={this.createMarkup()}/>
         
         <Row>
@@ -71,7 +123,28 @@ Lesson.propTypes = {
   lesson: PropTypes.shape({
     frontmatter: PropTypes.object,
     content: PropTypes.string
-  })
+  }),
+  path: PropTypes.string,
+  lessons: PropTypes.object,
+  isStudentMode: PropTypes.bool,
+  readmeContext: PropTypes.func,
+  setModeTeacher: PropTypes.func,
+  setLanguage: PropTypes.func
 };
 
-export default withStyles(styles, contentStyles)(Lesson);
+const mapStateToProps = (state) => {
+  return {
+    isStudentMode: state.isStudentMode,
+    lessons: state.lessons,
+    readmeContext: state.context.readmeContext,
+    language: state.language
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  {
+    setModeTeacher,
+    setLanguage
+  }
+  )(withStyles(styles, contentStyles)(Lesson));

--- a/src/components/LevelIcon.js
+++ b/src/components/LevelIcon.js
@@ -5,7 +5,7 @@ import styles from './LevelIcon.scss';
 
 const LevelIcon = React.createClass({
   render() {
-    return this.props.level ?
+    return this.props.level && this.props.level > 0 ?
       <img className={styles.levelIcon}
            src={require('../assets/graphics/level-' + this.props.level + '.svg')}/>
       : null;

--- a/src/components/LevelIcon.js
+++ b/src/components/LevelIcon.js
@@ -5,7 +5,7 @@ import styles from './LevelIcon.scss';
 
 const LevelIcon = React.createClass({
   render() {
-    return this.props.level && this.props.level > 0 ?
+    return this.props.level ?
       <img className={styles.levelIcon}
            src={require('../assets/graphics/level-' + this.props.level + '.svg')}/>
       : null;

--- a/src/components/Navigation/BreadCrumb.js
+++ b/src/components/Navigation/BreadCrumb.js
@@ -39,15 +39,11 @@ BreadCrumb.propTypes = {
 function mapStateToProps(state, ownProps) {
   const {course, lesson, file} = ownProps.params;
   const lessonPath = file ? `./${course}/${lesson}/${file}.md` : '';
-  const isReadme = (file && /README(_[\w]{2})?/.test(file));
+  const isReadme = (file && /README(_[a-z]{2})?/.test(file));
   let title = '';
 
   if(isReadme){
-    try {
-      title = state.context.readmeContext(lessonPath).frontmatter.title;
-    }catch(e){
-      title = '';
-    }
+    title = state.context.readmeContext(lessonPath).frontmatter.title || '';
   }
   return {
     iconContext: state.context.iconContext,

--- a/src/components/Navigation/BreadCrumb.js
+++ b/src/components/Navigation/BreadCrumb.js
@@ -46,7 +46,7 @@ function mapStateToProps(state, ownProps) {
     try {
       title = state.context.readmeContext(lessonPath).frontmatter.title;
     }catch(e){
-      title = 'No title';
+      title = '';
     }
   }
   return {

--- a/src/components/Navigation/BreadCrumb.js
+++ b/src/components/Navigation/BreadCrumb.js
@@ -39,7 +39,7 @@ BreadCrumb.propTypes = {
 function mapStateToProps(state, ownProps) {
   const {course, lesson, file} = ownProps.params;
   const lessonPath = file ? `./${course}/${lesson}/${file}.md` : '';
-  const isReadme = (file && /README_[\w]{2}/.test(file));
+  const isReadme = (file && /README[^\/]{0,3}/.test(file));
   let title = '';
 
   if(isReadme){

--- a/src/components/Navigation/BreadCrumb.js
+++ b/src/components/Navigation/BreadCrumb.js
@@ -39,7 +39,7 @@ BreadCrumb.propTypes = {
 function mapStateToProps(state, ownProps) {
   const {course, lesson, file} = ownProps.params;
   const lessonPath = file ? `./${course}/${lesson}/${file}.md` : '';
-  const isReadme = (file && /README[^\/]{0,3}/.test(file));
+  const isReadme = (file && /README(_[\w]{2})?/.test(file));
   let title = '';
 
   if(isReadme){

--- a/src/components/Navigation/BreadCrumb.js
+++ b/src/components/Navigation/BreadCrumb.js
@@ -39,10 +39,20 @@ BreadCrumb.propTypes = {
 function mapStateToProps(state, ownProps) {
   const {course, lesson, file} = ownProps.params;
   const lessonPath = file ? `./${course}/${lesson}/${file}.md` : '';
+  const isReadme = (file && /README_[\w]{2}/.test(file));
+  let title = '';
+
+  if(isReadme){
+    try {
+      title = state.context.readmeContext(lessonPath).frontmatter.title;
+    }catch(e){
+      title = 'No title';
+    }
+  }
   return {
     iconContext: state.context.iconContext,
-    lessonLevel: lessonPath ? state.lessons[lessonPath].level : 0,
-    lessonTitle: lessonPath ? state.lessons[lessonPath].title : '',
+    lessonLevel: lessonPath && !isReadme ? state.lessons[lessonPath].level : 0,
+    lessonTitle: lessonPath && !isReadme ? state.lessons[lessonPath].title : title,
   };
 }
 

--- a/src/components/PlaylistPage/LessonItem.js
+++ b/src/components/PlaylistPage/LessonItem.js
@@ -14,7 +14,9 @@ export const LessonItem = React.createClass({
     const levelIcon = <LevelIcon level={lesson.level}/>;
     const instructionBtn = !this.props.isStudentMode && lesson.readmePath ?
       <LinkContainer to={lesson.readmePath}>
-        <Button componentClass="div" className={styles.instructionBtn} bsStyle="guide" bsSize="xs">Veiledning</Button>
+        <Button componentClass="div" className={styles.instructionBtn}bsStyle="guide" bsSize="xs">
+          Lærerveiledning
+        </Button>
       </LinkContainer>
       : null;
     return (

--- a/src/routeObject.js
+++ b/src/routeObject.js
@@ -7,9 +7,11 @@ import store from './store';
 
 const lessons = store.getState().lessons;
 const courses = store.getState().context['courseContext'].keys();
+const readMePaths = store.getState().context['readmeContext'].keys();
 
 const lessonArray = Object.keys(lessons).map((key) => lessons[key]['path']);
 const courseArray = courses.map((course) => course.slice(1).replace(/\/index.md/i, ''));
+const readMeArray = readMePaths.map((course) => course.slice(1).replace(/\.md/i, ''));
 
 const validPathTest = (lesson, path) => {
   if(lesson){
@@ -33,10 +35,10 @@ const pathTest = (nextState, replace) => {
   if(path.lastIndexOf('/') === path.length-1){
     path = path.slice(0, -1);
   }
-  
+  const isReadMe = readMeArray.indexOf(path) > -1;
   const pathCorrect = validPathTest(params.lesson, path);
 
-  if(!pathCorrect){
+  if(!pathCorrect && !isReadMe){
     replace({pathname:'/PageNotFound', state: path});
   }
 };

--- a/src/routeObject.js
+++ b/src/routeObject.js
@@ -10,8 +10,8 @@ const courses = store.getState().context['courseContext'].keys();
 const readmePaths = store.getState().context['readmeContext'].keys();
 
 const lessonArray = Object.keys(lessons).map((key) => lessons[key]['path']);
-const courseArray = courses.map((course) => course.slice(1).replace(/\/index.md/i, ''));
-const readmeArray = readmePaths.map((course) => course.slice(1).replace(/\.md/i, ''));
+const courseArray = courses.map((course) => course.slice(1).replace(/\/index\.md/i, ''));
+const readmeArray = readmePaths.map((readmePath) => readmePath.slice(1).replace(/\.md/i, ''));
 
 const validPathTest = (lesson, path) => {
   if(lesson){

--- a/src/routeObject.js
+++ b/src/routeObject.js
@@ -7,11 +7,11 @@ import store from './store';
 
 const lessons = store.getState().lessons;
 const courses = store.getState().context['courseContext'].keys();
-const readMePaths = store.getState().context['readmeContext'].keys();
+const readmePaths = store.getState().context['readmeContext'].keys();
 
 const lessonArray = Object.keys(lessons).map((key) => lessons[key]['path']);
 const courseArray = courses.map((course) => course.slice(1).replace(/\/index.md/i, ''));
-const readMeArray = readMePaths.map((course) => course.slice(1).replace(/\.md/i, ''));
+const readmeArray = readmePaths.map((course) => course.slice(1).replace(/\.md/i, ''));
 
 const validPathTest = (lesson, path) => {
   if(lesson){
@@ -35,10 +35,10 @@ const pathTest = (nextState, replace) => {
   if(path.lastIndexOf('/') === path.length-1){
     path = path.slice(0, -1);
   }
-  const isReadMe = readMeArray.indexOf(path) > -1;
+  const isReadme = readmeArray.indexOf(path) > -1;
   const pathCorrect = validPathTest(params.lesson, path);
 
-  if(!pathCorrect && !isReadMe){
+  if(!pathCorrect && !isReadme){
     replace({pathname:'/PageNotFound', state: path});
   }
 };

--- a/src/routes-static.js
+++ b/src/routes-static.js
@@ -16,7 +16,7 @@ const getComponentLessonPage = (nextState, cb) => {
   const path = `${params.course}/${params.lesson}/${params.file}`;
 
   const lessonContext = require.context('frontAndContent!lessonSrc/', true,
-    /^\.\/[^\/]*\/[^\/]*\/(?!index\.md$|README\.md$)[^\/]*\.md/);
+    /^\.\/[^\/]*\/[^\/]*\/(?!index\.md$)[^\/]*\.md/);
   // console.log('SERVER: routes lessonContext.keys():');
   // console.log(lessonContext.keys());
   const result = lessonContext('./' + path + '.md');

--- a/src/routes-static.js
+++ b/src/routes-static.js
@@ -20,7 +20,7 @@ const getComponentLessonPage = (nextState, cb) => {
   // console.log('SERVER: routes lessonContext.keys():');
   // console.log(lessonContext.keys());
   const result = lessonContext('./' + path + '.md');
-  cb(null, props => <Lesson {...props} lesson={result}/>);
+  cb(null, props => <Lesson {...props} path={path} lesson={result}/>);
 };
 
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -25,7 +25,7 @@ const getComponentLessonPage = (nextState, cb) => {
   bundle(result => {
     // How to pass props directly to component,
     // see https://stackoverflow.com/questions/33571734/with-getcomponent-how-to-pass-props/33578098#33578098
-    cb(null, props => <Lesson {...props} lesson={result}/>);
+    cb(null, props => <Lesson {...props} path={path} lesson={result}/>);
   });
 
   // The following code was an attempt to make it look more like routes-static.js,

--- a/src/store.js
+++ b/src/store.js
@@ -9,9 +9,9 @@ const iconContext = require.context('lessonSrc/', true, /^\.\/[^\/]*\/logo-black
 const courseContext = require.context('onlyFrontmatter!lessonSrc/', true, /^\.\/[^\/]*\/index\.md/);
 const playlistContext = require.context('raw!lessonSrc/', true, /^\.\/[^\/]*\/playlists\/[^\/]*\.txt$/);
 const lessonContext = require.context('onlyFrontmatter!lessonSrc/', true,
-  /^\.\/[^\/]*\/[^\/]*\/(?!README(_[\w]{2})?\.md$)[^\/]*\.md/);
+  /^\.\/[^\/]*\/[^\/]*\/(?!README(_[a-z]{2})?\.md$)[^\/]*\.md/);
 const readmeContext = require.context('onlyFrontmatter!lessonSrc/', true,
-  /^\.\/[^\/]*\/[^\/]*\/README(_[\w]{2})?\.md$/);
+  /^\.\/[^\/]*\/[^\/]*\/README(_[a-z]{2})?\.md$/);
 const lessons = getLessons(lessonContext, readmeContext, courseContext);
 
 const initialState = {};

--- a/src/store.js
+++ b/src/store.js
@@ -9,9 +9,9 @@ const iconContext = require.context('lessonSrc/', true, /^\.\/[^\/]*\/logo-black
 const courseContext = require.context('onlyFrontmatter!lessonSrc/', true, /^\.\/[^\/]*\/index\.md/);
 const playlistContext = require.context('raw!lessonSrc/', true, /^\.\/[^\/]*\/playlists\/[^\/]*\.txt$/);
 const lessonContext = require.context('onlyFrontmatter!lessonSrc/', true,
-  /^\.\/[^\/]*\/[^\/]*\/(?!README[^\/]*\.md$)[^\/]*\.md/);
+  /^\.\/[^\/]*\/[^\/]*\/(?!README(_[\w]{2})?\.md$)[^\/]*\.md/);
 const readmeContext = require.context('onlyFrontmatter!lessonSrc/', true,
-  /^\.\/[^\/]*\/[^\/]*\/README[^\/]{0,3}\.md$/);
+  /^\.\/[^\/]*\/[^\/]*\/README(_[\w]{2})?\.md$/);
 const lessons = getLessons(lessonContext, readmeContext, courseContext);
 
 const initialState = {};

--- a/src/store.js
+++ b/src/store.js
@@ -9,9 +9,9 @@ const iconContext = require.context('lessonSrc/', true, /^\.\/[^\/]*\/logo-black
 const courseContext = require.context('onlyFrontmatter!lessonSrc/', true, /^\.\/[^\/]*\/index\.md/);
 const playlistContext = require.context('raw!lessonSrc/', true, /^\.\/[^\/]*\/playlists\/[^\/]*\.txt$/);
 const lessonContext = require.context('onlyFrontmatter!lessonSrc/', true,
-  /^\.\/[^\/]*\/[^\/]*\/(?!README\.md$)[^\/]*\.md/);
+  /^\.\/[^\/]*\/[^\/]*\/(?!README[^\/]*\.md$)[^\/]*\.md/);
 const readmeContext = require.context('onlyFrontmatter!lessonSrc/', true,
-  /^\.\/[^\/]*\/[^\/]*\/README\.md$/);
+  /^\.\/[^\/]*\/[^\/]*\/README_[\w]{2}\.md$/);
 const lessons = getLessons(lessonContext, readmeContext, courseContext);
 
 const initialState = {};
@@ -32,6 +32,7 @@ if (isProduction) {
 store.dispatch(setContext('iconContext', iconContext));
 store.dispatch(setContext('playlistContext', playlistContext));
 store.dispatch(setContext('courseContext', courseContext));
+store.dispatch(setContext('readmeContext', readmeContext));
 store.dispatch(setLessons(lessons));
 store.dispatch(setModeStudent());
 store.dispatch(setFilter(getTags(lessonContext, courseContext)));

--- a/src/store.js
+++ b/src/store.js
@@ -11,7 +11,7 @@ const playlistContext = require.context('raw!lessonSrc/', true, /^\.\/[^\/]*\/pl
 const lessonContext = require.context('onlyFrontmatter!lessonSrc/', true,
   /^\.\/[^\/]*\/[^\/]*\/(?!README[^\/]*\.md$)[^\/]*\.md/);
 const readmeContext = require.context('onlyFrontmatter!lessonSrc/', true,
-  /^\.\/[^\/]*\/[^\/]*\/README_[\w]{2}\.md$/);
+  /^\.\/[^\/]*\/[^\/]*\/README[^\/]{0,3}\.md$/);
 const lessons = getLessons(lessonContext, readmeContext, courseContext);
 
 const initialState = {};

--- a/src/util.js
+++ b/src/util.js
@@ -65,9 +65,9 @@ export function getLessons(lessonContext, readmeContext, courseContext) {
     const lessonTags = cleanseTags(lessonFrontmatter.tags, false);
     const tags = {...courseTags, ...lessonTags};
 
-    // Everything between '.' and last '/'. Add '/README' at the end
-    const readmePath = path.slice(1, path.lastIndexOf('/')) + '/README_' + language;
-    const hasReadme = readmeContext.keys().indexOf('.' + readmePath + '.md') !== -1;
+    // Gets the valid readmePath for the lesson, if it exists
+    const readmePath = getReadMePath(readmeContext, language, path.slice(1, path.lastIndexOf('/')));
+    const hasReadme = readmePath !== -1;
 
     res[path] = {
       title: lessonFrontmatter.title || '',
@@ -101,6 +101,26 @@ export function getInfo(context) {
 ///////////////////////////////////
 //////// HELPER FUNCTIONS /////////
 ///////////////////////////////////
+
+/**
+* Checks if a lesson with a given path has a README-file.
+* Accepts README-files on the form /README or /README_(ISO_CODE).
+**/
+const getReadMePath = (readmeContext, language, path) => {
+  const readmeContextKeys = readmeContext.keys();
+  const readmePathAndLanguageCode = path + '/README_' + language;
+  const readmePathNoLanguageCode = path + '/README';
+
+  if(readmeContextKeys.indexOf('.' + readmePathAndLanguageCode + '.md') !== -1){
+    return readmePathAndLanguageCode;
+  }
+  else if(readmeContextKeys.indexOf('.' + readmePathNoLanguageCode + '.md') !== -1){
+    if(language === readmeContext('.' + readmePathNoLanguageCode + '.md').frontmatter.language){
+      return path + '/README';
+    }
+  }
+  return -1;
+}
 
 /**
  * Fix invalid tags

--- a/src/util.js
+++ b/src/util.js
@@ -58,13 +58,15 @@ export function getLessons(lessonContext, readmeContext, courseContext) {
     const courseFrontmatter = courseContext(coursePath).frontmatter;
     const lessonFrontmatter = lessonContext(path).frontmatter;
 
+    const language = lessonFrontmatter.language;
+
     // Inherit tags from course, and override with lessonTags
     const courseTags = cleanseTags(courseFrontmatter.tags, false);
     const lessonTags = cleanseTags(lessonFrontmatter.tags, false);
     const tags = {...courseTags, ...lessonTags};
 
     // Everything between '.' and last '/'. Add '/README' at the end
-    const readmePath = path.slice(1, path.lastIndexOf('/')) + '/README';
+    const readmePath = path.slice(1, path.lastIndexOf('/')) + '/README_' + language;
     const hasReadme = readmeContext.keys().indexOf('.' + readmePath + '.md') !== -1;
 
     res[path] = {
@@ -75,6 +77,7 @@ export function getLessons(lessonContext, readmeContext, courseContext) {
       external: lessonFrontmatter.external || '',
       readmePath: hasReadme ? readmePath : '',
       course: courseName,
+      language: language,
       tags,
       // Everything between '.' and '.md'
       path: path.slice(1, path.length - 3)

--- a/src/util.js
+++ b/src/util.js
@@ -66,8 +66,7 @@ export function getLessons(lessonContext, readmeContext, courseContext) {
     const tags = {...courseTags, ...lessonTags};
 
     // Gets the valid readmePath for the lesson, if it exists
-    const readmePath = getReadMePath(readmeContext, language, path.slice(1, path.lastIndexOf('/')));
-    const hasReadme = readmePath !== -1;
+    const readmePath = getReadmePath(readmeContext, language, path);
 
     res[path] = {
       title: lessonFrontmatter.title || '',
@@ -75,7 +74,7 @@ export function getLessons(lessonContext, readmeContext, courseContext) {
       level: lessonFrontmatter.level,
       indexed: lessonFrontmatter.indexed == null ? true : lessonFrontmatter.indexed,
       external: lessonFrontmatter.external || '',
-      readmePath: hasReadme ? readmePath : '',
+      readmePath: readmePath,
       course: courseName,
       language: language,
       tags,
@@ -106,7 +105,8 @@ export function getInfo(context) {
 * Checks if a lesson with a given path has a README-file.
 * Accepts README-files on the form /README or /README_(ISO_CODE).
 **/
-const getReadMePath = (readmeContext, language, path) => {
+const getReadmePath = (readmeContext, language, path) => {
+  path = path.slice(1, path.lastIndexOf('/'));
   const readmeContextKeys = readmeContext.keys();
   const readmePathAndLanguageCode = path + '/README_' + language;
   const readmePathNoLanguageCode = path + '/README';
@@ -116,10 +116,10 @@ const getReadMePath = (readmeContext, language, path) => {
   }
   else if(readmeContextKeys.indexOf('.' + readmePathNoLanguageCode + '.md') !== -1){
     if(language === readmeContext('.' + readmePathNoLanguageCode + '.md').frontmatter.language){
-      return path + '/README';
+      return readmePathNoLanguageCode;
     }
   }
-  return -1;
+  return '';
 };
 
 /**
@@ -202,3 +202,18 @@ export function removeHtmlFileEnding(lessonPage) {
   // <a href= ../ followed by anything not containing whitespaces, and ends with .html">
   return lessonPage.replace(/(<a href="\.\.\/[^\s]*)\.html(">)/g, '$1$2');
 }
+
+/**
+* Returns the readmePath of a lesson with the given lessonPath
+*
+* @param {Object} lessons
+* @param {String} lessonPath
+* @returns {String or undefined}
+*/
+export const getReadmepathFromLessonpath = (lessons, lessonPath) => {
+  for(let key of Object.keys(lessons)){
+    if(lessons[key].readmePath === lessonPath){
+      return lessons[key]['external'] === '' ? lessons[key]['path'] : undefined;
+    }
+  }
+};

--- a/src/util.js
+++ b/src/util.js
@@ -120,7 +120,7 @@ const getReadMePath = (readmeContext, language, path) => {
     }
   }
   return -1;
-}
+};
 
 /**
  * Fix invalid tags

--- a/webpack.static.config.babel.js
+++ b/webpack.static.config.babel.js
@@ -54,7 +54,7 @@ function getStaticSitePaths() {
     .map(p => p.replace(new RegExp(`^${absLessonSrc}\/(.*)\/index\.md$`), '$1/'));
 
   const lessonPaths = glob.sync(path.join(absLessonSrc, '*/*/*.md'))
-    .filter(p => !p.endsWith('index.md') && !p.endsWith('README.md'))
+    .filter(p => !p.endsWith('index.md'))
     .filter(p => {
       const {title, external} = yamlFront.loadFront(p);
       if (external) { console.log('Skipping external course "' + title + '" (' + p + ')'); }


### PR DESCRIPTION
 #214 
Adds functionality for showing README-files for lessons in multiple languages. At the moment there is implemented support both for README-files on the form `/README` (the old way) and `/README_(a country's ISO code)` (the new way). For example: `/README_sv` for Swedish. This gives support for having multiple README-files in the same folder, but in different languages. When the old page is taken down, all README-files should be named on the form `/README_(a country's ISO code)`.
A list of new features:

- The veiledning-buttons (renamed to "Lærerveiledning") showing on the PlaylistPage, when in teacher mode, for lessons that has a registered README-file, now links to the coresponding README-file.

- When in teacher mode, there will also be a button with a direct link from a lesson page to the corresponding README page (if the README-file exists, else the button will not show).

- When on a README page, there will be a button with a direct link to the corresponding lesson page.

- When you have typed in a direct URL to a README page, you will automatically be put into teacher mode.

- (The following functionality is commented out in the code until language is further implemented)
When you have typed a direct URL to a lesson page or a README page, the language state will automatically be set to the language corresponding to the lesson or README file.