### PR TITLE
Add back the course info button which was accidentally removed earlier

### DIFF
--- a/src/pages/PlaylistPage.js
+++ b/src/pages/PlaylistPage.js
@@ -11,10 +11,14 @@ import LessonList from '../components/PlaylistPage/LessonList';
 import LevelNavigation from '../components/PlaylistPage/LevelNavigation';
 import PlaylistNavigation from '../components/PlaylistPage/PlaylistNavigation';
 import HeadRow from '../components/PlaylistPage/HeadRow';
+import CourseInfo from '../components/PlaylistPage/CourseInfo';
 
 import Col from 'react-bootstrap/lib/Col';
 import Grid from 'react-bootstrap/lib/Grid';
 import Row from 'react-bootstrap/lib/Row';
+import Button from 'react-bootstrap/lib/Button';
+import Glyphicon from 'react-bootstrap/lib/Glyphicon';
+import Collapse from 'react-bootstrap/lib/Collapse';
 
 export const PlaylistPage = React.createClass({
   getLessonsByLevel(lessons) {
@@ -73,20 +77,49 @@ export const PlaylistPage = React.createClass({
     return (
       <Grid fluid={true}>
 
-        {/*Title with course name*/}
-        <HeadRow courseName={this.props.params.course}/>
+        {/*Title with course name and get started button*/}
+        <Row>
+          <Col xs={12} sm={6} smOffset={3}>
+            <div className={styles.headerRow}>
+              <HeadRow courseName={this.props.params.course}/>
+              <Button bsStyle="guide" className={styles.courseInfoBtn} onClick={() => this.changeState()}>
+                <Glyphicon className={styles.glyph} glyph={!this.state.showCourseInfo ? 'plus-sign' : 'minus-sign'}/>
+                Informasjon om kurset
+              </Button>
+            </div>
+          </Col>
+        </Row>
 
         <Row>
           {/*Filter desktop*/}
           <Col xsHidden>
             <Col sm={3}>{filter}</Col>
-            <Col sm={6}>{playlistsAndLessons}</Col>
+
+            {this.state.showCourseInfo ?
+              <Col sm={6}>
+                <Collapse in={this.state.showCourseInfo}>
+                   <CourseInfo courseName={this.props.params.course} isStudentMode={this.props.isStudentMode}/>
+                </Collapse>
+                {playlistsAndLessons}
+              </Col>
+            :
+              <Col sm={6}>{playlistsAndLessons}</Col>
+            }
+
             <Col sm={3}>{jumpTo}</Col>
           </Col>
 
           {/*Filter mobile*/}
           <Col smHidden mdHidden lgHidden>
+            {this.state.showCourseInfo ?
+              <Col xs={12}>
+                <Collapse in={this.state.showCourseInfo}>
+                   <CourseInfo courseName={this.props.params.course} isStudentMode={this.props.isStudentMode}/>
+                </Collapse>
+              {filter}</Col>
+            :
             <Col xs={12}>{filter}</Col>
+            }
             <Col xs={12}>{jumpTo}</Col>
             <Col xs={12}>{playlistsAndLessons}</Col>
           </Col>

--- a/src/pages/PlaylistPage.js
+++ b/src/pages/PlaylistPage.js
@@ -74,6 +74,11 @@ export const PlaylistPage = React.createClass({
         {showLevelNavigationDesktop ? <LevelNavigation levels={levels}/> : null}
       </div>;
 
+    const courseInfo =
+      <Collapse in={this.state.showCourseInfo}>
+        <CourseInfo courseName={this.props.params.course} isStudentMode={this.props.isStudentMode}/>
+      </Collapse>;
+
     return (
       <Grid fluid={true}>
 
@@ -94,18 +99,14 @@ export const PlaylistPage = React.createClass({
           {/*Filter desktop*/}
           <Col xsHidden>
             <Col sm={3}>{filter}</Col>
-
             {this.state.showCourseInfo ?
               <Col sm={6}>
-                <Collapse in={this.state.showCourseInfo}>
-                   <CourseInfo courseName={this.props.params.course} isStudentMode={this.props.isStudentMode}/>
-                </Collapse>
+                {courseInfo}
                 {playlistsAndLessons}
               </Col>
             :
               <Col sm={6}>{playlistsAndLessons}</Col>
             }
-
             <Col sm={3}>{jumpTo}</Col>
           </Col>
 
@@ -113,12 +114,11 @@ export const PlaylistPage = React.createClass({
           <Col smHidden mdHidden lgHidden>
             {this.state.showCourseInfo ?
               <Col xs={12}>
-                <Collapse in={this.state.showCourseInfo}>
-                   <CourseInfo courseName={this.props.params.course} isStudentMode={this.props.isStudentMode}/>
-                </Collapse>
-              {filter}</Col>
+                {courseInfo}
+                {filter}
+              </Col>
             :
-            <Col xs={12}>{filter}</Col>
+              <Col xs={12}>{filter}</Col>
             }
             <Col xs={12}>{jumpTo}</Col>
             <Col xs={12}>{playlistsAndLessons}</Col>


### PR DESCRIPTION
The course info button added by @krskog accidentally didn't make it into my last PR #239 (see image). I added it back again, adjusted to the new way of displaying the content on the page.
<img width="1413" alt="skjermbilde 2017-05-12 kl 11 00 32" src="https://cloud.githubusercontent.com/assets/10497878/25991060/410295a0-3702-11e7-9563-a0c1f9cc7c88.png">
