### PR TITLE
Fix incorrect serverside styling

### DIFF
--- a/src/components/Navigation/NavBar.js
+++ b/src/components/Navigation/NavBar.js
@@ -169,26 +169,28 @@ function MenuToggle(props) {
 export function NavBar(props) {
   const widgetClass = props.isStudentMode ? styles.widgetStudent : styles.widgetTeacher;
   return (
-    <Navbar fluid={true} staticTop>
-      <Navbar.Header>
-        <LkkBrand/>
-        <Clearfix visibleXsBlock/>
-        <MenuToggle t={props.t}/>
-      </Navbar.Header>
-      <Navbar.Collapse>
-        <div className={styles.spacing}/>
-        <LkkNav t={props.t}/>
-      </Navbar.Collapse>
-      <div className={styles.widgets + ' ' + widgetClass}>
-        <BreadCrumb params={props.params}/>
-        <Gadgets language={props.language}
-                 setLanguage={props.setLanguage}
-                 setModeStudent={props.setModeStudent}
-                 setModeTeacher={props.setModeTeacher}
-                 isStudentMode={props.isStudentMode}
-                 t={props.t}/>
-      </div>
-    </Navbar>
+    <div className={styles.navbarWrapper}>
+      <Navbar fluid={true} staticTop>
+        <Navbar.Header>
+          <LkkBrand/>
+          <Clearfix visibleXsBlock/>
+          <MenuToggle t={props.t}/>
+        </Navbar.Header>
+        <Navbar.Collapse>
+          <div className={styles.spacing}/>
+          <LkkNav t={props.t}/>
+        </Navbar.Collapse>
+        <div className={styles.widgets + ' ' + widgetClass}>
+          <BreadCrumb params={props.params}/>
+          <Gadgets language={props.language}
+                   setLanguage={props.setLanguage}
+                   setModeStudent={props.setModeStudent}
+                   setModeTeacher={props.setModeTeacher}
+                   isStudentMode={props.isStudentMode}
+                   t={props.t}/>
+        </div>
+      </Navbar>
+    </div>
   );
 }
 NavBar.propTypes = {

--- a/src/components/Navigation/NavBar.scss
+++ b/src/components/Navigation/NavBar.scss
@@ -6,101 +6,103 @@ $space-between-text-and-flag: 10px;
 $logo-height: 127px;
 $widget-height: 50px;
 
-:global {
-  .navbar > .container-fluid {
-    padding: 0;
-    & .navbar-header {
-      margin: 0;
-    }
-    & .navbar-collapse {
-      margin: 0;
+.navbarWrapper {
+  :global {
+    .navbar > .container-fluid {
       padding: 0;
-    }
-  }
-
-  .navbar-nav {
-    margin: 0;
-  }
-
-  .navbar-brand {
-    padding: 0 10px;
-  }
-
-  .navbar-default {
-    background-color: $lkk-offwhite;
-    & .navbar-nav {
-      background-color: transparent;
-      & > li > a {
-        color: $lkk-grey;
-        &:focus {
-          color: $lkk-green;
-          background-color: transparent;
-        }
-        &:hover {
-          color: $lkk-green;
-          background-color: transparent;
-        }
+      & .navbar-header {
+        margin: 0;
       }
-      & > .active > a {
-        &,
-        &:focus,
-        &:hover {
-          color: $lkk-green;
-          background-color: transparent;
-        }
+      & .navbar-collapse {
+        margin: 0;
+        padding: 0;
       }
     }
-  }
 
-  .navbar-toggle.navbar-toggle { // write twice to increase specificity
-    float: none;
-    border: 0;
-    border-radius: 0;
-    margin: 0;
-    width: 100%;
-    color: white;
-    font-size: 1.2em;
-    &,
-    &:focus {
-      background-color: $lkk-dark-grey;
+    .navbar-nav {
+      margin: 0;
     }
-    &:hover {
-      background-color: $lkk-green;
-    }
-    & .icon-bar {
-      background-color: white;
-    }
-  }
 
-  @media (max-width: $screen-xs-max) {
-    .navbar-header {
-      text-align: center;
-    }
     .navbar-brand {
-      float: none;
-      display: inline-block;
-      padding: 0;
+      padding: 0 10px;
     }
+
     .navbar-default {
+      background-color: $lkk-offwhite;
       & .navbar-nav {
-        background-color: $lkk-dark-grey;
+        background-color: transparent;
         & > li > a {
-          color: white;
+          color: $lkk-grey;
           &:focus {
-            color: white;
-            background-color: $lkk-dark-grey;
+            color: $lkk-green;
+            background-color: transparent;
           }
           &:hover {
-            color: white;
-            background-color: $lkk-green;
+            color: $lkk-green;
+            background-color: transparent;
           }
         }
         & > .active > a {
           &,
           &:focus,
           &:hover {
+            color: $lkk-green;
+            background-color: transparent;
+          }
+        }
+      }
+    }
+
+    .navbar-toggle.navbar-toggle { // write twice to increase specificity
+      float: none;
+      border: 0;
+      border-radius: 0;
+      margin: 0;
+      width: 100%;
+      color: white;
+      font-size: 1.2em;
+      &,
+      &:focus {
+        background-color: $lkk-dark-grey;
+      }
+      &:hover {
+        background-color: $lkk-green;
+      }
+      & .icon-bar {
+        background-color: white;
+      }
+    }
+
+    @media (max-width: $screen-xs-max) {
+      .navbar-header {
+        text-align: center;
+      }
+      .navbar-brand {
+        float: none;
+        display: inline-block;
+        padding: 0;
+      }
+      .navbar-default {
+        & .navbar-nav {
+          background-color: $lkk-dark-grey;
+          & > li > a {
             color: white;
-            background-color: $lkk-green;
+            &:focus {
+              color: white;
+              background-color: $lkk-dark-grey;
+            }
+            &:hover {
+              color: white;
+              background-color: $lkk-green;
+            }
+          }
+          & > .active > a {
+            &,
+            &:focus,
+            &:hover {
+              color: white;
+              background-color: $lkk-green;
+            }
           }
         }
       }

--- a/src/index-template.ejs
+++ b/src/index-template.ejs
@@ -4,9 +4,18 @@
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title><%= htmlWebpackPlugin.options.title %></title>
+
+    <% for (key in htmlWebpackPlugin.files.css) { %>
+    <link href="<%= htmlWebpackPlugin.files.css[key] %>" rel="stylesheet">
+    <% } %>
+
     <%= htmlWebpackPlugin.options.appcss %>
 </head>
 <body>
     <div id="app"><%= htmlWebpackPlugin.options.appcontent %></div>
+
+    <% for (key in htmlWebpackPlugin.files.chunks) { %>
+    <script src="<%= htmlWebpackPlugin.files.chunks[key].entry %>" type="text/javascript"></script>
+    <% } %>
 </body>
 </html>

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -104,7 +104,7 @@ function getPlugins() {
     new HtmlWebpackPlugin({
       title: 'Kodeklubben',
       template: 'src/index-template.ejs',
-      inject: 'body',
+      inject: false,
       chunksSortMode: 'dependency' // Make sure they are loaded in the right order in index.html
     }),
     // Create template for the static non-root index.html files
@@ -114,7 +114,7 @@ function getPlugins() {
       appcss: '<%= appCss %>',
       appcontent: '<%= appHtml %>',
       template: 'src/index-template.ejs',
-      inject: 'body',
+      inject: false,
       chunksSortMode: 'dependency' // Make sure they are loaded in the right order in index.html
     }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
Does 2 things:
1) All use of `:global` should be wrapped by a "local" class when using css-modules. The reason is that if not, it might affect css other places on the page (we are changing global), and also if the global css is loaded first, the specificity of the global space might win. The NavBar was (as far as I coulds see) the only css that used `:global` without a wrapper, so I added this.

2) When injecting `<link>` tags for the extracted css-files, they were inserted after the css `<style>` tags inserted from the isomorphic-style plugin. To fix this, I needed to turn off the automatic injection and "manually" specify in the template where the css should be injected.

These changes will probably only be seen when building and serving the static site.