### PR TITLE
Simplify yarn serve, adding config of local-web-server in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "yarn run buildjs && yarn run buildstatic",
     "build:prod": "yarn run buildjs:prod && yarn run buildstatic",
     "build:prod:travis": "cross-env NODE_ENV=production webpack -p && webpack --config=webpack.static.config.babel.js",
-    "serve": "ws -p 8080 -c -d ./dist -s index.html",
+    "serve": "ws",
     "servejs": "node ./server.js",
     "test": "mocha --compilers js:babel-core/register --require ./test/test_helper.js \"test/**/*@(.js|.jsx)\"",
     "test:watch": "yarn run test -- --watch",
@@ -40,6 +40,11 @@
       "react",
       "stage-2"
     ]
+  },
+  "local-web-server": {
+    "port": 8080,
+    "directory": "./dist",
+    "compress": true
   },
   "dependencies": {
     "highlight.js": "^9.11.0",


### PR DESCRIPTION
Inserted the config of local-web-server in package.json, so that it is possible to just write `ws` in the command line instead of `yarn serve` (both er possible). To see the config, write `ws --config`.

Also removed the `-s index.html`, since it was a bit to eager to redirect to the index.html (it was originally added to simulate the 404-behaviour on github, but it does not behave the same way). Although it is still not like github, it is better.