### PR TITLE
Issue 314 sort filteritems

### DIFF
--- a/src/components/Filter/FilterGroup.js
+++ b/src/components/Filter/FilterGroup.js
@@ -23,7 +23,12 @@ const FilterGroup = ({
       const checked = filterTags[key];
       return tagName ? <FilterItem {...{key, checked, tagName, onCheck}}/>
         : null;
-    });
+    }).filter(item => !!item); // filter out null-values;
+
+    // Sort filterItems alphabetically except grades
+    if (groupKey !== 'grade') {
+      filterItems.sort((a, b) => a.props.tagName.localeCompare(b.props.tagName));
+    }
 
     const nothingChecked = !somethingChecked;
     const isCollapsed = nothingChecked && filterGroupsCollapsed[groupKey];
@@ -33,21 +38,6 @@ const FilterGroup = ({
         collapseFilterGroup(groupKey, !isCollapsed);
       }
     };
-
-    /* Sort filterItems alphabetically
-    ** Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
-    */ 
-    if (groupKey !== 'grade') {
-      filterItems.sort((a, b) => {
-        if (a.props.tagName < b.props.tagName) {
-          return -1;
-        }
-        if (a.props.tagName > b.props.tagName) {
-          return 1;
-        }
-        return 0;
-      });
-    }
 
     return (
       <ListGroupItem>

--- a/src/components/Filter/FilterGroup.js
+++ b/src/components/Filter/FilterGroup.js
@@ -33,6 +33,22 @@ const FilterGroup = ({
         collapseFilterGroup(groupKey, !isCollapsed);
       }
     };
+
+    /* Sort filterItems alphabetically
+    ** Taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
+    */ 
+    if (groupKey !== 'grade') {
+      filterItems.sort((a, b) => {
+        if (a.props.tagName < b.props.tagName) {
+          return -1;
+        }
+        if (a.props.tagName > b.props.tagName) {
+          return 1;
+        }
+        return 0;
+      });
+    }
+
     return (
       <ListGroupItem>
         <div className={headingStyle} onClick={onGroupClick}>


### PR DESCRIPTION
Solves #314 

Right now the filter items it's in the same order as it is in keys.md.

But I think everything should be alphabetically except grades. 

Don't know if this is the best way to do it, but it works for every language and it's taken for Mozillas developer site for the sort function

If we don't want this, I think we could just close issue 314