### PR TITLE
Issue 386 and oppgaverepo issue 626 - redirect html

### DIFF
--- a/createLessonPdfs.js
+++ b/createLessonPdfs.js
@@ -55,7 +55,7 @@ const convertUrl = async (browser, lesson) => {
 };
 
 const doConvert = () => {
-  const lessons = lessonPaths({verbose: false}).map(path => path.replace(/\/$/, ''));
+  const lessons = lessonPaths();
 
   (async () => {
     const browser = await puppeteer.launch();

--- a/lws.config.js
+++ b/lws.config.js
@@ -6,6 +6,8 @@ module.exports = {
   compress: true,
   verbose: false,
   rewrite: [
-    { from: /^(.*[/][^.]+)$/, to: '$1.html'}, // Fake github's behaviour, that with no extension, assume .html
+    // Fake github's behaviour, that with no extension, assume .html
+    { from: /^(.*[/][^.]+)$/, to: '$1.html'},           // .../file       --> .../file.html
+    { from: /^(.*[/][^.]+)\?(.+)$/, to: '$1.html?$2'},  // .../file?query --> .../file.html?query
   ],
 };

--- a/lws.config.js
+++ b/lws.config.js
@@ -3,5 +3,9 @@
 module.exports = {
   port: 8080,
   directory: './dist',
-  compress: true
+  compress: true,
+  verbose: false,
+  rewrite: [
+    { from: /^(.*[/][^.]+)$/, to: '$1.html'}, // Fake github's behaviour, that with no extension, assume .html
+  ],
 };

--- a/pathlists.js
+++ b/pathlists.js
@@ -7,14 +7,15 @@ const glob = require('glob');
 const lessonSrcPath = lessonSrc.replace(/\\/g, '/');
 
 
-module.exports.coursePaths = () => {
+module.exports.coursePaths = (ending) => {
+  if (typeof ending === 'undefined') { ending = ''; }
   return glob.sync(path.join(lessonSrcPath, '*/index.md'), {dot: true})
-    .map(p => p.replace(new RegExp(`^${lessonSrcPath}/(.*)/index\\.md$`), '$1/'));
+    .map(p => p.replace(new RegExp(`^${lessonSrcPath}/(.*)/index\\.md$`), '$1' + ending));
 };
 
 module.exports.lessonPaths = (verbose, ending) => {
   if (typeof verbose === 'undefined') { verbose = true; }
-  if (typeof ending === 'undefined') { ending = '/'; }
+  if (typeof ending === 'undefined') { ending = ''; }
   const availableLanguages = yamlFront.loadFront(path.join(lessonFiltertags, 'keys.md')).language;
   console.log('Available languages:', availableLanguages);
   return glob.sync(path.join(lessonSrcPath, '*/*/*.md'))

--- a/pathlists.js
+++ b/pathlists.js
@@ -13,9 +13,9 @@ module.exports.coursePaths = (ending) => {
     .map(p => p.replace(new RegExp(`^${lessonSrcPath}/(.*)/index\\.md$`), '$1' + ending));
 };
 
-module.exports.lessonPaths = (verbose, ending) => {
-  if (typeof verbose === 'undefined') { verbose = true; }
+module.exports.lessonPaths = (ending, verbose) => {
   if (typeof ending === 'undefined') { ending = ''; }
+  if (typeof verbose === 'undefined') { verbose = false; }
   const availableLanguages = yamlFront.loadFront(path.join(lessonFiltertags, 'keys.md')).language;
   console.log('Available languages:', availableLanguages);
   return glob.sync(path.join(lessonSrcPath, '*/*/*.md'))

--- a/src/components/Lesson/Lesson.js
+++ b/src/components/Lesson/Lesson.js
@@ -13,8 +13,7 @@ import contentStyles from './Content.scss';
 import ImprovePage from './ImprovePage.js';
 import Row from 'react-bootstrap/lib/Row';
 import {getTranslator, getTranslateTag, getTranslateGroup} from '../../selectors/translate';
-import {capitalize, removeHtmlFileEnding,
-  setCheckboxes, anyCheckboxTrue, createCheckboxesKey} from '../../util';
+import {capitalize, setCheckboxes, anyCheckboxTrue, createCheckboxesKey} from '../../util';
 import {getTitle, getLevel, getTags, getAuthorName, getTranslatorName} from '../../selectors/frontmatter';
 import {setCheckbox, setLastLesson} from '../../action_creators';
 import MarkdownRenderer from '../MarkdownRenderer';
@@ -40,7 +39,7 @@ const rememberLastLesson = (path, setLastLesson) => {
 };
 
 const createMarkup = (lessonContent) => {
-  return ({__html: removeHtmlFileEnding(processContent(lessonContent, contentStyles))});
+  return ({__html: processContent(lessonContent, contentStyles)});
 };
 
 const PrintInfo = ({t, translateTag, translateGroup, course, tags}) =>

--- a/src/index-static.js
+++ b/src/index-static.js
@@ -11,7 +11,8 @@ import store from './store';
 
 export default (locals, callback) => {
   const history = createMemoryHistory();
-  const location = history.createLocation(locals.path);
+  const pathWithoutHtml = locals.path.replace(/\.html$/, '');
+  const location = history.createLocation(pathWithoutHtml);
 
   match({ routes, location }, (error, redirectLocation, renderProps) => {
     let css = [];

--- a/src/routeObject.js
+++ b/src/routeObject.js
@@ -59,7 +59,7 @@ const pathTest = (nextState, replace) => {
 const saveURL = (nextState, replace) => {
   const publicPath = process.env.PUBLICPATH_WITHOUT_SLASH;
   const path = (publicPath === '/') ? nextState.location.state : publicPath + nextState.location.state;
-  if(typeof history.replaceState !== 'undefined'){
+  if(typeof history !== 'undefined' && history.replaceState){
     history.replaceState(null, null, path);
   }
 };
@@ -82,10 +82,17 @@ const serverSideRedirectCheck = (nextState, replace) => {
 
 const rewritePath = (nextState, replace) => {
   const nextpath = nextState.location.pathname;
-  // XXX: if nextpath === '/index.html' the redirect to '/' ?
-  if (nextpath !== '/index.html' && nextpath.endsWith('.html')) {
+  if (nextpath.startsWith('/index')) {
     if (typeof document !== 'undefined') {
-      replace(nextpath.replace(/\.html$/, ''));
+      replace('/' + nextState.location.search);
+    } else {
+      console.error('The router cannot handle paths that start with /index' +
+        ' when rendering static pages (' + nextpath + ')');
+    }
+  }
+  else if (nextpath.endsWith('.html')) {
+    if (typeof document !== 'undefined') {
+      replace(nextpath.replace(/\.html$/, '') + nextState.location.search);
     } else {
       console.error('The router cannot handle paths that end in .html' +
         ' when rendering static pages (' + nextpath + ')');

--- a/src/routeObject.js
+++ b/src/routeObject.js
@@ -80,6 +80,27 @@ const serverSideRedirectCheck = (nextState, replace) => {
   }
 };
 
+const rewritePath = (nextState, replace) => {
+  const nextpath = nextState.location.pathname;
+  // XXX: if nextpath === '/index.html' the redirect to '/' ?
+  if (nextpath !== '/index.html' && nextpath.endsWith('.html')) {
+    if (typeof document !== 'undefined') {
+      replace(nextpath.replace(/\.html$/, ''));
+    } else {
+      console.error('The router cannot handle paths that end in .html' +
+        ' when rendering static pages (' + nextpath + ')');
+    }
+  }
+};
+
+const appOnEnter = (nextState, replace) => {
+  rewritePath(nextState, replace);
+};
+
+const appOnChange = (prevState, nextState, replace) => {
+  rewritePath(nextState, replace);
+};
+
 /**
 * IMPORTANT:
 * When adding new routes, especially dynamic ones (on the form path="/:somePath")
@@ -93,7 +114,7 @@ export default function getRouteObject(
   getComponentNotFound
 ) {
   return (
-    <Route path="/" component={App}>
+    <Route path="/" component={App} onEnter={appOnEnter} onChange={appOnChange}>
       <IndexRoute getComponent={getComponentFrontPage} onEnter={serverSideRedirectCheck}/>
       <Route path="/PageNotFound" getComponent={getComponentNotFound} onEnter={saveURL}/>
       <Route path="/:course" getComponent={getComponentPlaylist} onEnter={pathTest}/>

--- a/src/util.js
+++ b/src/util.js
@@ -300,12 +300,6 @@ export function tagsMatchFilter(lessonTags, filter) {
   return true; // The lessonTags contained all the checked filterTags
 }
 
-export function removeHtmlFileEnding(lessonPage) {
-  // RegEx for matching and removing parts of text that starts with
-  // <a href= ../ followed by anything not containing whitespaces, and ends with .html">
-  return lessonPage.replace(/(<a href="\.\.\/[^\s]*)\.html(")/g, '$1$2');
-}
-
 /**
 * Returns languages defined as available
 * All available languages must be defined here

--- a/test/util_spec.js
+++ b/test/util_spec.js
@@ -8,7 +8,6 @@ import {
   cleanseTags,
   fixNonArrayTagList,
   tagsMatchFilter,
-  removeHtmlFileEnding,
   arrayToObject,
 } from '../src/util';
 
@@ -240,40 +239,6 @@ describe('util', () => {
       deepFreeze(tags);
       deepFreeze(filter);
       expect(tagsMatchFilter(tags, filter)).to.equal(false);
-    });
-  });
-
-  describe('removeHtmlFileEnding', () => {
-    it('simple test to see that .html is removed correctly', () => {
-      const testString = '<a href="../stuff.html">“html HTML> .html .html>"</a>';
-      const correctString = '<a href="../stuff">“html HTML> .html .html>"</a>';
-      expect(removeHtmlFileEnding(testString)).to.equal(correctString);
-    });
-
-    it('Returns true if string is unchanged', () => {
-      const testString = '../html"> .html"> ../.html> ../.html"';
-      expect(removeHtmlFileEnding(testString)).to.equal(testString);
-    });
-
-    it('Checks that multiple links are correctly edited', () => {
-      const testString = '<a href="../del_inn_nettsiden/del_inn_nettsiden.html">“Del inn nettsiden"</a>\
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam eleifend sit amet nulla nec consectetur.\
-<a href="../forsvunnet_katt/forsvunnet_katt.html">Forvunnet katt</a>';
-      const correctString = '<a href="../del_inn_nettsiden/del_inn_nettsiden">“Del inn nettsiden"</a>\
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam eleifend sit amet nulla nec consectetur.\
-<a href="../forsvunnet_katt/forsvunnet_katt">Forvunnet katt</a>';
-      expect(removeHtmlFileEnding(testString)).to.equal(correctString);
-    });
-
-    it('Returns true if ".html" ending is removed from string of gibberish', () => {
-      const testString = '<a href="../we/write&some-.,Bull*#¤here+-*and)(-"seIF<>the++?/regEx_will?=)\
-(/&%¤#"!remove"The.,Ending^~correctly,We__æøå_alsoPut&%In__Somehtml_words,likeHtml.or.HTML.html_htmlstuff\
-The_Only.thing.that.should.be&removed*is,the".html".ending.html">“html HTML> .html .html>"</a>';
-
-      const correctString = '<a href="../we/write&some-.,Bull*#¤here+-*and)(-"seIF<>the++?/regEx_will?=)\
-(/&%¤#"!remove"The.,Ending^~correctly,We__æøå_alsoPut&%In__Somehtml_words,likeHtml.or.HTML.html_htmlstuff\
-The_Only.thing.that.should.be&removed*is,the".html".ending">“html HTML> .html .html>"</a>';
-      expect(removeHtmlFileEnding(testString)).to.equal(correctString);
     });
   });
 

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -153,7 +153,7 @@ function getPlugins() {
   if (!buildPDF) {
     // copy FakeLessonPDF.pdf to all the lessons
     // (with the same name as the .md-file, e.g. astrokatt.md --> astrokatt.pdf)
-    const pdfPaths = lessonPaths(false, '.pdf');
+    const pdfPaths = lessonPaths('.pdf');
     plugins = plugins.concat([
       new CopyWebpackPlugin(pdfPaths.map(pdfPath => ({
         from: 'src/assets/pdfs/FakeLessonPDF.pdf',

--- a/webpack.static.config.babel.js
+++ b/webpack.static.config.babel.js
@@ -58,7 +58,7 @@ const locals = {};
 ///////////////
 
 function getStaticSitePaths() {
-  const staticPaths = ['/'].concat(coursePaths()).concat(lessonPaths());
+  const staticPaths = ['/'].concat(coursePaths('.html')).concat(lessonPaths(false, '.html'));
   //const staticPaths = ['scratch/astrokatt/astrokatt'];
 
   console.log('Static paths:');

--- a/webpack.static.config.babel.js
+++ b/webpack.static.config.babel.js
@@ -58,18 +58,17 @@ const locals = {};
 ///////////////
 
 function getStaticSitePaths() {
-  const staticPaths = ['/'].concat(coursePaths('.html')).concat(lessonPaths(false, '.html'));
-  //const staticPaths = ['scratch/astrokatt/astrokatt'];
+  // The '/' will render to '/index.html'
+  const paths = [
+    '/',  // Is the same as '/index.html'
+    'PageNotFound.html',
+  ];
+  const courses = coursePaths('.html');
+  const lessons = lessonPaths('.html');
 
+  const staticPaths = paths.concat(courses).concat(lessons);
   console.log('Static paths:');
   console.log(staticPaths);
-
-  // [
-  //   '/scratch',
-  //    ... (more courses)
-  //   'scratch/3d_flakser/3d_flakser_1',
-  //    ... (more lessons)
-  // ]
 
   return staticPaths;
 }


### PR DESCRIPTION
Solves #386 and https://github.com/kodeklubben/oppgaver/issues/626

Lesson no longer removes html-endings. The router does this in the browser.

Renders static html to e.g. scratch/julekort/julekort.html instead of scratch/julekort/julekort/index.html

Also added rewrite rules to local-web-server so that it understands that `scratch/julekort/julekort` means `scratch/julekort/julekort/index.html` (like github does).
