### PR TITLE
Comment scratchblocks back in

### DIFF
--- a/src/components/Lesson/Content.scss
+++ b/src/components/Lesson/Content.scss
@@ -47,7 +47,7 @@ $checkbox-blue: #abdbea;
   @include styledList;
 }
 
- scratch code blocks
+// scratch code blocks
 pre.blocks,
 code.b {
   background-color: inherit;

--- a/src/components/Lesson/Content.scss
+++ b/src/components/Lesson/Content.scss
@@ -47,12 +47,12 @@ $checkbox-blue: #abdbea;
   @include styledList;
 }
 
-// scratch code blocks
-//pre.blocks,
-//code.b {
-//  background-color: inherit;
-//  border: 0;
-//}
+ scratch code blocks
+pre.blocks,
+code.b {
+  background-color: inherit;
+  border: 0;
+}
 
 // code blocks
 pre > code {


### PR DESCRIPTION
Comment scratchblocks back in. Was commented out in puppeteer PR (#422). Not sure why. Without this, scratchblocks are not rendered.