### PR TITLE
Add url_path_prefix (aka publicPath) in statically rendered html-files

### DIFF
--- a/createLessonPdfs.js
+++ b/createLessonPdfs.js
@@ -8,7 +8,7 @@ const fse = require('fs-extra');
 const {buildDir, publicPath} = require('./buildconstants');
 const {lessonPaths} = require('./pathlists');
 
-const numberOfSimultaneousPdfConverts = 10;
+const numberOfSimultaneousPdfConverts = 8;
 const urlBase = 'http://127.0.0.1:8080' + publicPath;
 let localWebServer = null;
 

--- a/lws.config.js
+++ b/lws.config.js
@@ -7,6 +7,7 @@ module.exports = {
   verbose: false,
   rewrite: [
     // Fake github's behaviour, that with no extension, assume .html
+    { from: /^(.*[/])$/, to: '$1index.html'},           // .../           --> .../index.html
     { from: /^(.*[/][^.]+)$/, to: '$1.html'},           // .../file       --> .../file.html
     { from: /^(.*[/][^.]+)\?(.+)$/, to: '$1.html?$2'},  // .../file?query --> .../file.html?query
   ],

--- a/src/html-template.ejs
+++ b/src/html-template.ejs
@@ -9,7 +9,7 @@
     <title><%- pageTitle -%></title>
 
     <% cssAssets.forEach(function(file){ %>
-    <link href="/<%- file -%>" rel="stylesheet">
+    <link href="<%- file -%>" rel="stylesheet">
     <% }); %>
 
     <%- appCss -%>
@@ -18,7 +18,7 @@
     <div id="app"><%- appHtml -%></div>
 
     <% jsAssets.forEach(function(file){ %>
-    <script src="/<%- file -%>" async></script>
+    <script src="<%- file -%>" async></script>
     <% }); %>
 </body>
 </html>

--- a/src/renderStatic.js
+++ b/src/renderStatic.js
@@ -36,7 +36,7 @@ const renderStatic = (locals, callback) => {
 
     const appCss = css.length ? `<style type="text/css">${css.join('')}</style>` : '';
     const pageTitle =  DocumentTitle.rewind();
-    const assets = Object.keys(locals.webpackStats.compilation.assets);
+    const assets = Object.keys(locals.webpackStats.compilation.assets).map(p => locals.publicPath + p);
     const cssAssets = assets.filter(value => value.match(/\.css$/));
     const jsAssets = assets.filter(value => value.match(/\.js$/));
     const html = template({ cssAssets, jsAssets, appCss, appHtml, pageTitle });

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -331,7 +331,9 @@ const createConfig = (env = {}) => {
         new StaticSiteGeneratorPlugin({
           entry: 'main',
           paths: staticSitePaths,
-          locals: {},
+          locals: {
+            publicPath,
+          },
           globals: {
             window: {}
           }


### PR DESCRIPTION
url_path_prefix aka publicPath aka `/beta` manglet foran css og js-filene i de statisk genererte html-filene etter at vi oppdaterte til webpack 2. Dette skulle fikse det.