### PR TITLE
Antall oppgaver for CourseItem

### DIFF
--- a/src/components/CourseList/CourseItem.js
+++ b/src/components/CourseList/CourseItem.js
@@ -9,7 +9,7 @@ import Glyphicon from 'react-bootstrap/lib/Glyphicon';
 import {getTranslator} from '../../selectors/translate';
 import PopoverComponent from '../PopoverComponent';
 
-const CourseItem = ({course, t, language, showPlaylists}) => {
+const CourseItem = ({course, t, language, hideLessonCount}) => {
   const isExternal = course.hasOwnProperty('externalLink');
   const coursePath = course.name.replace(/ /g, '_').toLowerCase();
   const introPath = coursePath + '/index' + (isExternal || language === 'nb' ? '' : ('_' + language));
@@ -35,7 +35,7 @@ const CourseItem = ({course, t, language, showPlaylists}) => {
           <span className={styles.courseName}>{course.name}
             {popoverButton}
           </span>
-          {showPlaylists ? null :
+          {hideLessonCount ? null :
             <span className={styles.lessonCount}>{t('playlist.lessons')}: {course.lessonCount}</span>
           }
         </Link>
@@ -56,13 +56,13 @@ CourseItem.propTypes = {
   // mapStateToProps
   t: PropTypes.func.isRequired,
   language: PropTypes.string.isRequired,
-  showPlaylists: PropTypes.bool.isRequired,
+  hideLessonCount: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = (state) => ({
   t: getTranslator(state),
   language: state.language,
-  showPlaylists: state.showPlaylists,
+  hideLessonCount: state.showPlaylists && state.language === 'nb',
 });
 
 export default connect(

--- a/src/components/CourseList/CourseItem.js
+++ b/src/components/CourseList/CourseItem.js
@@ -8,8 +8,9 @@ import Link from 'react-router/lib/Link';
 import Glyphicon from 'react-bootstrap/lib/Glyphicon';
 import {getTranslator} from '../../selectors/translate';
 import PopoverComponent from '../PopoverComponent';
+import {getShowFiltergroups} from '../../selectors/playlist';
 
-const CourseItem = ({course, t, language, hideLessonCount}) => {
+const CourseItem = ({course, t, language, showLessonCount}) => {
   const isExternal = course.hasOwnProperty('externalLink');
   const coursePath = course.name.replace(/ /g, '_').toLowerCase();
   const introPath = coursePath + '/index' + (isExternal || language === 'nb' ? '' : ('_' + language));
@@ -35,8 +36,9 @@ const CourseItem = ({course, t, language, hideLessonCount}) => {
           <span className={styles.courseName}>{course.name}
             {popoverButton}
           </span>
-          {hideLessonCount ? null :
-            <span className={styles.lessonCount}>{t('playlist.lessons')}: {course.lessonCount}</span>
+          {showLessonCount ?
+            <span className={styles.lessonCount}>{t('playlist.lessons')}: {course.lessonCount}</span> :
+            null
           }
         </Link>
       }
@@ -56,13 +58,13 @@ CourseItem.propTypes = {
   // mapStateToProps
   t: PropTypes.func.isRequired,
   language: PropTypes.string.isRequired,
-  hideLessonCount: PropTypes.bool.isRequired,
+  showLessonCount: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = (state) => ({
   t: getTranslator(state),
   language: state.language,
-  hideLessonCount: state.showPlaylists && state.language === 'nb',
+  showLessonCount: getShowFiltergroups(state),
 });
 
 export default connect(

--- a/src/components/Filter/LessonFilter.js
+++ b/src/components/Filter/LessonFilter.js
@@ -5,7 +5,7 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import styles from './LessonFilter.scss';
 import Panel from 'react-bootstrap/lib/Panel';
 import {getTranslator} from '../../selectors/translate';
-import {getShowRadiobuttons} from '../../selectors/playlist';
+import {getShowRadiobuttons, getShowFiltergroups} from '../../selectors/playlist';
 import FilterGroup from './FilterGroup';
 import RadioButtons from './RadioButtons';
 import PopoverComponent from '../PopoverComponent';
@@ -64,16 +64,13 @@ LessonFilter.propTypes = {
   showFiltergroups: PropTypes.bool.isRequired,
 };
 
-const mapStateToProps = (state, {courseName}) => {
-  const showRadiobuttons = getShowRadiobuttons(state, courseName);
-  return {
-    filterGroupKeys: Object.keys(state.filter),
-    isStudentMode: state.isStudentMode,
-    t: getTranslator(state),
-    showRadiobuttons,
-    showFiltergroups: !state.showPlaylists || !showRadiobuttons,
-  };
-};
+const mapStateToProps = (state, {courseName}) => ({
+  filterGroupKeys: Object.keys(state.filter),
+  isStudentMode: state.isStudentMode,
+  t: getTranslator(state),
+  showRadiobuttons: getShowRadiobuttons(state, courseName),
+  showFiltergroups: getShowFiltergroups(state, courseName),
+});
 
 export default connect(
   mapStateToProps

--- a/src/selectors/playlist.js
+++ b/src/selectors/playlist.js
@@ -47,3 +47,10 @@ export const getPlaylists = createSelector(
  */
 export const getShowRadiobuttons = (state, courseName) =>
   state.language === 'nb' && Object.keys(getPlaylists(state, courseName)).length > 0;
+
+/**
+ * Returns a boolean that says if the filtergroups in the filter should be displayed
+ * Input props: courseName (string, optional)
+ */
+export const getShowFiltergroups = (state, courseName) =>
+  !state.showPlaylists || !getShowRadiobuttons(state, courseName);


### PR DESCRIPTION
Fant en liten bug der antall oppgaver ble borte fra CourseItem. Hvis jeg f.eks. gikk fra norsk til engelsk, for hovedspråk, og jeg hadde tidligere huket av for Oppgavesamlinger på norsk, så endret filteret seg riktig, men antall oppgaver var fortsatt ikke synlig