### PR TITLE
Get tags from data.yml

### DIFF
--- a/buildconstants.js
+++ b/buildconstants.js
@@ -16,7 +16,8 @@ const isHot = process.argv.indexOf('--hot') >= 0;
 // Webpack needs final slash in publicPath to rewrite relative paths correctly
 const publicPathWithoutSlash = '/' + subDir;
 const publicPath = '/' + subDir + (subDir ? '/' : '');
-const lessonSrc = path.resolve(__dirname, '../oppgaver/src');
+const lessonRepo = path.resolve(__dirname, '../oppgaver');
+const lessonSrc = path.resolve(lessonRepo, 'src');
 const lessonFiltertags = path.resolve(__dirname, '../oppgaver/filtertags');
 const assets = path.resolve(__dirname, './src/assets');
 const bootstrapStyles = path.resolve(__dirname, './node_modules/bootstrap-sass/assets/stylesheets/bootstrap');
@@ -29,6 +30,7 @@ module.exports = {
   isHot,
   publicPathWithoutSlash,
   publicPath,
+  lessonRepo,
   lessonSrc,
   lessonFiltertags,
   assets,

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "webpack": "3.10.0",
     "webpack-dev-server": "^2.11.2",
     "webpack-shell-plugin": "^0.5.0",
-    "yaml-front-matter": "^3.4.0"
+    "yaml-front-matter": "^3.4.0",
+    "yml-loader": "^2.1.0"
   }
 }

--- a/src/contexts.js
+++ b/src/contexts.js
@@ -28,6 +28,14 @@ export const readmeContext =
 export const lessonAllContext =
   require.context('lessonSrc/', true, /^[.][/][^/]*[/][^/]*[/][^.]*[.]md$/);
 
+// lessonSrc/*/data.yml
+const courseDataContext =
+  require.context('lessonSrc/', true, /^[.][/][^/]+[/]data[.]yml$/);
+
+// lessonSrc/*/*/data.yml
+const lessonDataContext =
+  require.context('lessonSrc/', true, /^[.][/][^/]+[/][^/]+[/]data[.]yml$/);
+
 ////////////////////////////
 // Context util functions //
 ////////////////////////////
@@ -49,3 +57,30 @@ const readmePathArray = readmeContext.keys().map(extractLessonPath);
 export const isValidLessonPath = (path) => lessonPathArray.includes(path);
 export const isValidReadmePath = (path) => readmePathArray.includes(path);
 export const isValidCoursePath = (path) => coursePathArray.includes(path);
+
+/**
+ * Returns a json-object corresponding to a data.yml file from course or lesson
+ * @param {string} path Starts with './' and ends without a slash, e.g. './scratch' or './scratch/astrokatt'
+ * @param {context} context A require.context with data.yml files
+ * @returns {object} A json-object with data from data.yml
+ */
+const getMetadata = (path, context) => {
+  const dataPath = path + '/data.yml';
+  // if (context.keys().includes(dataPath)) {
+  //   const data = context(dataPath);
+  //   console.log('data.yml', dataPath, data, data.tags);
+  // }
+  return context.keys().includes(dataPath) ? context(dataPath) : {};
+};
+
+/**
+ * @param {string} path The course path, e.g. './scratch'
+ * @returns {Object} See getMetadata()
+ */
+export const getCourseMetadata = (path) => getMetadata(path, courseDataContext);
+
+/**
+ * @param {string} path The lesson path, e.g. './scratch/astrokatt'
+ * @returns {Object} See getMetadata()
+ */
+export const getLessonMetadata = (path) => getMetadata(path, lessonDataContext);

--- a/src/selectors/course.js
+++ b/src/selectors/course.js
@@ -1,7 +1,7 @@
 import {createSelector} from 'reselect';
 import {getFilteredAndIndexedLessons} from './lesson';
 import {capitalize, tagsMatchFilter, cleanseTags} from '../util';
-import {iconContext, courseContext} from '../contexts';
+import {iconContext, courseContext, getCourseMetadata} from '../contexts';
 
 const getFilter = (state) => state.filter;
 
@@ -35,12 +35,13 @@ export const getFilteredExternalCourses = createSelector(
     return courseContext.keys().reduce((res, path) => {
       const coursePath = path.slice(0, path.indexOf('/', 2));
       const fm = courseContext(path).frontmatter;
+      const courseMeta = getCourseMetadata(path);
       if (fm.external != null) {
         const course = {
           externalLink: fm.external,
           iconPath: iconContext(coursePath + '/logo-black.png'),
           name: fm.title,
-          tags: cleanseTags({...(fm.tags || {}), language: [fm.language]}, 'external course ' + coursePath)
+          tags: cleanseTags({...(courseMeta.tags || {}), language: [fm.language]}, 'external course ' + coursePath)
         };
         return tagsMatchFilter(course.tags, filter) ? {...res, [fm.title]: course} : res;
       }

--- a/src/selectors/frontmatter.js
+++ b/src/selectors/frontmatter.js
@@ -6,6 +6,7 @@ const getLessonFrontmatter = (state, {course, lesson, file}) => {
   const lessons = getLessonData();
   const lessonPath = `./${course}/${lesson}/${file}.md`;
   const isReadme = /README(_[a-z]{2})?/.test(file);
+  // NOTE: Frontmatter for README does not contain tags anymore.
   return isReadme ? readmeContext(lessonPath).frontmatter : (lessons[lessonPath] || {});
 };
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,13 @@
 /* eslint-env node */
 
-import {courseContext, readmeContext, lessonContext, courseAllLangsContext, lessonAllContext} from './contexts';
+import {
+  readmeContext,
+  lessonContext,
+  courseAllLangsContext,
+  lessonAllContext,
+  getCourseMetadata,
+  getLessonMetadata,
+} from './contexts';
 
 /**
  * Makes first character in str upper case
@@ -97,12 +104,13 @@ export function getLessonData() {
 
       // Course name is between './' and second '/'
       const courseName = path.slice(2, path.indexOf('/', 2)).toLowerCase();
-      const coursePath = path.slice(0, path.indexOf('/', 2)) + '/index.md';
-      const courseFrontmatter = courseContext(coursePath).frontmatter;
+
+      const lessonMetaPath = dirname(path);
+      const courseMetaPath = dirname(lessonMetaPath);
 
       // Inherit tags from course, override with lessonTags, and add lessonTag
-      const courseTags = cleanseTags(courseFrontmatter.tags, 'course ' + coursePath);
-      const lessonTags = cleanseTags(lessonFrontmatter.tags, 'lesson ' + path);
+      const courseTags = cleanseTags(getCourseMetadata(courseMetaPath).tags, 'course ' + courseMetaPath);
+      const lessonTags = cleanseTags(getLessonMetadata(lessonMetaPath).tags, 'lesson ' + lessonMetaPath);
       const languageTag = language ? {language: [language]} : {};
       const tags = {...courseTags, ...lessonTags, ...languageTag};
 

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -61,6 +61,7 @@ import {
   filenameBase,
   isHot,
   lessonFiltertags,
+  lessonRepo,
   lessonSrc,
   publicPath,
   publicPathWithoutSlash,
@@ -104,6 +105,7 @@ const createConfig = (env = {}) => {
   // All RegExps that involve paths must have the path parts surrounded by regexpCompPath
   const regexpCompPath = (str) => path.normalize(str).replace(/\\/g, '\\\\');
   const inCurrentRepo = (extRegexp) => new RegExp('^' + regexpCompPath(__dirname) + '.*\\.' + extRegexp + '$');
+  const inLessonRepo = (extRegexp) => new RegExp('^' + regexpCompPath(lessonRepo) + '.*\\.' + extRegexp + '$');
 
   const config = {
     context: __dirname,
@@ -205,15 +207,19 @@ const createConfig = (env = {}) => {
           options: {name: 'CCV-assets/[name].[hash:6].[ext]'},
         },
         {
-          test: /\.txt$/,
-          loader: 'raw-loader',
-        },
-        {
-          test: /\.ejs$/,
+          test: inCurrentRepo('ejs'),
           loader: 'ejs-compiled-loader',
         },
         {
-          test: /\.md$/,
+          test: inLessonRepo('txt'),
+          loader: 'raw-loader',
+        },
+        {
+          test: inLessonRepo('ya?ml'),
+          loader: 'yml-loader',
+        },
+        {
+          test: inLessonRepo('md'),
           loader: 'combine-loader',
           options: {
             //raw: 'raw-loader',
@@ -229,8 +235,7 @@ const createConfig = (env = {}) => {
           },
         },
         {
-          test: (absPath) => absPath.startsWith(lessonSrc), // only in lesson repo
-          exclude: [/\.md$/, new RegExp(regexpCompPath('/playlists/') + '.*\\.txt$')],
+          test: inLessonRepo('png'),
           loader: 'file-loader',
           options: {name: '[path][name].[hash:6].[ext]'},
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4638,6 +4638,13 @@ js-yaml@^3.7.0:
     argparse "^1.0.7"
     esprima "^3.1.1"
 
+js-yaml@^3.8.3:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
@@ -8959,3 +8966,10 @@ yauzl@2.4.1:
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
   dependencies:
     fd-slicer "~1.0.1"
+
+yml-loader@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/yml-loader/-/yml-loader-2.1.0.tgz#b976b8691b537b6d3dc7d92a9a7d34b90de10870"
+  dependencies:
+    js-yaml "^3.8.3"
+    loader-utils "^1.1.0"


### PR DESCRIPTION
Update to get tags from data.yml instead of the frontmatter of courses and lessons.

This is needed when https://github.com/kodeklubben/oppgaver/pull/656 is merged.