### PR TITLE
Issue 465 Add alt to images

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,13 @@
     "react/jsx-uses-vars": [1],      // avoid no-unused-vars for imports used as react components
     "react/jsx-uses-react": [1],     // avoid no-unused-vars for importing React
     "react/react-in-jsx-scope": [1], // make sure React is in scope when writing jsx
-    "no-var": ["error"]
+    "no-var": ["error"],
+    "jsx-a11y/label-has-for": [ 2, {
+      "components": [ "Label" ],
+      "required": {
+      "every": [ "nesting", "id" ]},
+      "allowChildren": true
+      }
+    ]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
     "es6": true,
     "mocha": true
   },
-  "extends": "eslint:recommended",
+  "extends": ["eslint:recommended", "plugin:jsx-a11y/recommended"],
   "parser": "babel-eslint",
   "parserOptions": {
     "ecmaVersion": 8,
@@ -15,7 +15,7 @@
     },
     "sourceType": "module"
   },
-  "plugins": ["react"],
+  "plugins": ["react", "jsx-a11y"],
   "rules": {
     "eol-last": ["error"],
     "indent": ["error", 2, {"SwitchCase": 1}],

--- a/.eslintrc
+++ b/.eslintrc
@@ -28,10 +28,11 @@
     "react/jsx-uses-react": [1],     // avoid no-unused-vars for importing React
     "react/react-in-jsx-scope": [1], // make sure React is in scope when writing jsx
     "no-var": ["error"],
-    "jsx-a11y/label-has-for": [ 2, {
+    "jsx-a11y/label-has-for": [ "error", {
       "components": [ "Label" ],
       "required": {
-      "every": [ "nesting", "id" ]},
+        "every": [ "nesting", "id" ]
+      },
       "allowChildren": true
       }
     ]

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "deep-freeze": "^0.0.1",
     "ejs-compiled-loader": "^1.1.0",
     "eslint": "^4.6.1",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.3.0",
     "express": "^4.16.3",
     "extract-text-webpack-plugin": "^3.0.2",

--- a/src/components/CourseList/CourseItem.js
+++ b/src/components/CourseList/CourseItem.js
@@ -6,7 +6,6 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import {getLessonIntro} from '../../util';
 import Link from 'react-router/lib/Link';
 import Glyphicon from 'react-bootstrap/lib/Glyphicon';
-import Image from 'react-bootstrap/lib/Image';
 import {getTranslator} from '../../selectors/translate';
 import PopoverComponent from '../PopoverComponent';
 import {getShowFiltergroups} from '../../selectors/playlist';
@@ -25,7 +24,7 @@ const CourseItem = ({course, t, language, showLessonCount}) => {
     <div>
       {isExternal ?
         <a className={styles.courseItem} href={course.externalLink} target='_blank'>
-          <Image className={styles.courseLogo} src={course.iconPath} alt={course.name}/>
+          <img className={styles.courseLogo} src={course.iconPath} alt={course.name}/>
           <span className={styles.courseName}>{course.name}
             {popoverButton}
             <Glyphicon className={styles.externalGlyph} glyph='new-window'/>
@@ -33,7 +32,7 @@ const CourseItem = ({course, t, language, showLessonCount}) => {
         </a>
         :
         <Link className={styles.courseItem} to={course.path}>
-          <Image className={styles.courseLogo} src={course.iconPath} alt={course.name}/>
+          <img className={styles.courseLogo} src={course.iconPath} alt={course.name}/>
           <span className={styles.courseName}>{course.name}
             {popoverButton}
           </span>

--- a/src/components/CourseList/CourseItem.js
+++ b/src/components/CourseList/CourseItem.js
@@ -6,6 +6,7 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import {getLessonIntro} from '../../util';
 import Link from 'react-router/lib/Link';
 import Glyphicon from 'react-bootstrap/lib/Glyphicon';
+import Image from 'react-bootstrap/lib/Image';
 import {getTranslator} from '../../selectors/translate';
 import PopoverComponent from '../PopoverComponent';
 import {getShowFiltergroups} from '../../selectors/playlist';
@@ -24,7 +25,7 @@ const CourseItem = ({course, t, language, showLessonCount}) => {
     <div>
       {isExternal ?
         <a className={styles.courseItem} href={course.externalLink} target='_blank'>
-          <img className={styles.courseLogo} src={course.iconPath}/>
+          <Image className={styles.courseLogo} src={course.iconPath} alt={course.name}/>
           <span className={styles.courseName}>{course.name}
             {popoverButton}
             <Glyphicon className={styles.externalGlyph} glyph='new-window'/>
@@ -32,7 +33,7 @@ const CourseItem = ({course, t, language, showLessonCount}) => {
         </a>
         :
         <Link className={styles.courseItem} to={course.path}>
-          <img className={styles.courseLogo} src={course.iconPath}/>
+          <Image className={styles.courseLogo} src={course.iconPath} alt={course.name}/>
           <span className={styles.courseName}>{course.name}
             {popoverButton}
           </span>

--- a/src/components/Filter/FilterGroup.js
+++ b/src/components/Filter/FilterGroup.js
@@ -42,8 +42,8 @@ const FilterGroup = ({
     };
 
     return (
-      <ListGroupItem onClick={onGroupClick}>
-        <div className={headingStyle}>
+      <ListGroupItem>
+        <div className={headingStyle} onClick={onGroupClick} role='button' tabIndex='0' onKeyPress={onGroupClick}>
           <Glyphicon className={styles.glyph} glyph={isCollapsed ? 'chevron-right' : 'chevron-down'}/>
           {groupName}
         </div>

--- a/src/components/Filter/FilterGroup.js
+++ b/src/components/Filter/FilterGroup.js
@@ -40,16 +40,10 @@ const FilterGroup = ({
         collapseFilterGroup(groupKey, !isCollapsed);
       }
     };
-    
+
     return (
-      <ListGroupItem>
-        <div
-          role='button'
-          tabIndex='0'
-          className={headingStyle}
-          onClick={onGroupClick}
-          onKeyPress={e => console.log(e.keyCode)}
-        >
+      <ListGroupItem onClick={onGroupClick}>
+        <div className={headingStyle}>
           <Glyphicon className={styles.glyph} glyph={isCollapsed ? 'chevron-right' : 'chevron-down'}/>
           {groupName}
         </div>

--- a/src/components/Filter/FilterGroup.js
+++ b/src/components/Filter/FilterGroup.js
@@ -40,10 +40,16 @@ const FilterGroup = ({
         collapseFilterGroup(groupKey, !isCollapsed);
       }
     };
-
+    
     return (
       <ListGroupItem>
-        <div className={headingStyle} onClick={onGroupClick}>
+        <div
+          role='button'
+          tabIndex='0'
+          className={headingStyle}
+          onClick={onGroupClick}
+          onKeyPress={e => console.log(e.keyCode)}
+        >
           <Glyphicon className={styles.glyph} glyph={isCollapsed ? 'chevron-right' : 'chevron-down'}/>
           {groupName}
         </div>

--- a/src/components/Filter/FilterItem.js
+++ b/src/components/Filter/FilterItem.js
@@ -6,8 +6,8 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 const FilterItem = ({tagName, checked, onCheck}) => {
   return (
     <div className="checkbox">
-      <label className={styles.label}>
-        <input type="checkbox" onChange={onCheck} {...{checked}}/>
+      <label htmlFor={tagName} className={styles.label}>
+        <input id={tagName} type="checkbox" onChange={onCheck} {...{checked}}/>
         <span>{tagName}</span>
       </label>
     </div>

--- a/src/components/Filter/FilterItem.js
+++ b/src/components/Filter/FilterItem.js
@@ -6,8 +6,8 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 const FilterItem = ({tagName, checked, onCheck}) => {
   return (
     <div className="checkbox">
-      <label htmlFor={tagName} className={styles.label}>
-        <input id={tagName} type="checkbox" onChange={onCheck} {...{checked}}/>
+      <label className={styles.label}>
+        <input type="checkbox" onChange={onCheck} {...{checked}}/>
         <span>{tagName}</span>
       </label>
     </div>

--- a/src/components/Filter/RadioButtons.js
+++ b/src/components/Filter/RadioButtons.js
@@ -10,8 +10,8 @@ import {collapseAllFilterGroups} from '../../reducers/filterGroupsCollapsed';
 
 const RadioButtons = ({showPlaylists, language, t, setShowPlaylists, resetAllFilters, collapseAllFilterGroups}) => {
   const RadioButton = ({checked, onChange, text}) =>
-    <label className={styles.label}>
-      <input type='radio' name='radioGroup' {...{checked, onChange}}/>
+    <label htmlFor={text} className={styles.label}>
+      <input id={text} type='radio' name='radioGroup' {...{checked, onChange}}/>
       <span className={styles.marginLeft}>{text}</span>
     </label>;
   return (

--- a/src/components/Filter/RadioButtons.js
+++ b/src/components/Filter/RadioButtons.js
@@ -10,8 +10,8 @@ import {collapseAllFilterGroups} from '../../reducers/filterGroupsCollapsed';
 
 const RadioButtons = ({showPlaylists, language, t, setShowPlaylists, resetAllFilters, collapseAllFilterGroups}) => {
   const RadioButton = ({checked, onChange, text}) =>
-    <label htmlFor={text} className={styles.label}>
-      <input id={text} type='radio' name='radioGroup' {...{checked, onChange}}/>
+    <label className={styles.label}>
+      <input type='radio' name='radioGroup' {...{checked, onChange}}/>
       <span className={styles.marginLeft}>{text}</span>
     </label>;
   return (

--- a/src/components/FrontPage/TeacherInfobox.js
+++ b/src/components/FrontPage/TeacherInfobox.js
@@ -32,7 +32,7 @@ class TeacherInfobox extends React.Component {
           {t('frontpage.teacherinfobox.changemode')}
           <br />
           <div className={styles.center}>
-            <Button className={styles.plusSign} onClick={() => this.changeState()}>
+            <Button className={styles.plusSign} onClick={() => this.changeState()} aria-label='Button for expanding'>
               <Glyphicon glyph={!showCourseInfo ? 'plus-sign' : 'minus-sign'}/>
             </Button>
           </div>

--- a/src/components/FrontPage/TeacherInfobox.js
+++ b/src/components/FrontPage/TeacherInfobox.js
@@ -23,7 +23,7 @@ class TeacherInfobox extends React.Component {
       'http://kidsakoder.no/skole/valgfag/',
       'http://kidsakoder.no/kodeklubben/'
     ];
-
+    const ariaLabel = showCourseInfo ? t('frontpage.teacherinfobox.minus') : t('frontpage.teacherinfobox.plus');
     return (
       <div className={styles.center}>
         <div className={styles.infoBox}>
@@ -32,7 +32,7 @@ class TeacherInfobox extends React.Component {
           {t('frontpage.teacherinfobox.changemode')}
           <br />
           <div className={styles.center}>
-            <Button className={styles.plusSign} onClick={() => this.changeState()} aria-label='Button for expanding'>
+            <Button className={styles.plusSign} onClick={() => this.changeState()} aria-label={ariaLabel}>
               <Glyphicon glyph={!showCourseInfo ? 'plus-sign' : 'minus-sign'}/>
             </Button>
           </div>

--- a/src/components/InstructionButton.js
+++ b/src/components/InstructionButton.js
@@ -10,10 +10,9 @@ const InstructionButton = ({buttonPath, buttonText, className, bsSize, insideLin
   const isNotReadme = buttonPath ? buttonPath.includes('README') : false;
   const bsStyle = 'guide';
   const componentClass = insideLink ? 'div' : 'a';
-  const ariaLabel = isNotReadme ? 'Teacher instructions' : 'Lesson';
   return (buttonPath ?
     <LinkContainer to={buttonPath}>
-      <Button {...{className, bsStyle, bsSize, componentClass}} aria-label={ariaLabel}>
+      <Button {...{className, bsStyle, bsSize, componentClass}} aria-label={buttonText}>
         <Glyphicon className={styles.icon} glyph={isNotReadme ? 'education' : 'pencil'}/>
         <span className={buttonText ? styles.textMargin : ''}>{buttonText}</span>
       </Button>

--- a/src/components/InstructionButton.js
+++ b/src/components/InstructionButton.js
@@ -10,9 +10,10 @@ const InstructionButton = ({buttonPath, buttonText, className, bsSize, insideLin
   const isNotReadme = buttonPath ? buttonPath.includes('README') : false;
   const bsStyle = 'guide';
   const componentClass = insideLink ? 'div' : 'a';
+  const ariaLabel = isNotReadme ? 'Teacher instructions' : 'Lesson';
   return (buttonPath ?
     <LinkContainer to={buttonPath}>
-      <Button {...{className, bsStyle, bsSize, componentClass}}>
+      <Button {...{className, bsStyle, bsSize, componentClass}} aria-label={ariaLabel}>
         <Glyphicon className={styles.icon} glyph={isNotReadme ? 'education' : 'pencil'}/>
         <span className={buttonText ? styles.textMargin : ''}>{buttonText}</span>
       </Button>

--- a/src/components/Lesson/MainLanguageButton.js
+++ b/src/components/Lesson/MainLanguageButton.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import Button from 'react-bootstrap/lib/Button';
-import Image from 'react-bootstrap/lib/Image';
 import LinkContainer from 'react-router-bootstrap/lib/LinkContainer';
 import styles from './MainLanguageButton.scss';
 import {getPathForMainLanguage} from '../../util';
@@ -18,9 +17,7 @@ const MainLanguageButton = ({path, t, tt, isReadme, language}) => {
   return buttonPath === null ? null :
     <LinkContainer to={buttonPath}>
       <Button {...{className, bsStyle, bsSize}}>
-        <Image
-          className={styles.flag}
-          src={require(`../../assets/graphics/flag_${language}.svg`)}
+        <img className={styles.flag} src={require(`../../assets/graphics/flag_${language}.svg`)}
           alt={tt('language', language)}
         />
         <span className={styles.textMargin}>

--- a/src/components/Lesson/MainLanguageButton.js
+++ b/src/components/Lesson/MainLanguageButton.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import Button from 'react-bootstrap/lib/Button';
+import Image from 'react-bootstrap/lib/Image';
 import LinkContainer from 'react-router-bootstrap/lib/LinkContainer';
 import styles from './MainLanguageButton.scss';
 import {getPathForMainLanguage} from '../../util';
@@ -17,7 +18,11 @@ const MainLanguageButton = ({path, t, tt, isReadme, language}) => {
   return buttonPath === null ? null :
     <LinkContainer to={buttonPath}>
       <Button {...{className, bsStyle, bsSize}}>
-        <img className={styles.flag} src={require(`../../assets/graphics/flag_${language}.svg`)}/>
+        <Image
+          className={styles.flag}
+          src={require(`../../assets/graphics/flag_${language}.svg`)}
+          alt={tt('language', language)}
+        />
         <span className={styles.textMargin}>
           {t('lessons.tomainlanguage', {lang: tt('language', language)})}
         </span>

--- a/src/components/Lesson/PdfButton.js
+++ b/src/components/Lesson/PdfButton.js
@@ -18,7 +18,7 @@ const PdfButton = ({t, href}) => {
   // Note that we need to use href in button, and not LinkContainer,
   // since we don't want to go through React Router when getting the pdf.
   return (
-    <Button {...options} aria-label='Download PDF'>
+    <Button {...options} aria-label={t('lessons.pdf')}>
       <Glyphicon className={styles.icon} glyph={'cloud-download'}/>
       <span className={styles.textMargin}>{t('lessons.pdf')}</span>
     </Button>

--- a/src/components/Lesson/PdfButton.js
+++ b/src/components/Lesson/PdfButton.js
@@ -18,7 +18,7 @@ const PdfButton = ({t, href}) => {
   // Note that we need to use href in button, and not LinkContainer,
   // since we don't want to go through React Router when getting the pdf.
   return (
-    <Button {...options}>
+    <Button {...options} aria-label='Download PDF'>
       <Glyphicon className={styles.icon} glyph={'cloud-download'}/>
       <span className={styles.textMargin}>{t('lessons.pdf')}</span>
     </Button>

--- a/src/components/Lesson/ResetButton.js
+++ b/src/components/Lesson/ResetButton.js
@@ -15,7 +15,7 @@ const ResetButton = ({path, t, setCheckbox}) => {
   const onClick = () => setCheckboxes(path, {}, setCheckbox);
   const className = styles.container;
   return (
-    <Button {...{className, bsSize, bsStyle, onClick}}>
+    <Button {...{className, bsSize, bsStyle, onClick}} aria-label={'Reset lesson'}>
       <Glyphicon className={styles.icon} glyph={'remove'}/>
       <span className={styles.textMargin}>{t('lessons.reset')}</span>
     </Button>

--- a/src/components/Lesson/ResetButton.js
+++ b/src/components/Lesson/ResetButton.js
@@ -15,7 +15,7 @@ const ResetButton = ({path, t, setCheckbox}) => {
   const onClick = () => setCheckboxes(path, {}, setCheckbox);
   const className = styles.container;
   return (
-    <Button {...{className, bsSize, bsStyle, onClick}} aria-label={'Reset lesson'}>
+    <Button {...{className, bsSize, bsStyle, onClick}} aria-label={t('lessons.reset')}>
       <Glyphicon className={styles.icon} glyph={'remove'}/>
       <span className={styles.textMargin}>{t('lessons.reset')}</span>
     </Button>

--- a/src/components/LevelIcon.js
+++ b/src/components/LevelIcon.js
@@ -2,10 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import styles from './LevelIcon.scss';
+import Image from 'react-bootstrap/lib/Image';
 
 const LevelIcon = ({level}) => {
   return level ?
-    <img className={styles.levelIcon} src={require('../assets/graphics/level-' + level + '.svg')}/>
+    <Image className={styles.levelIcon} src={require('../assets/graphics/level-' + level + '.svg')}
+      alt={'Level' + level}
+    />
     : null;
 };
 

--- a/src/components/LevelIcon.js
+++ b/src/components/LevelIcon.js
@@ -2,11 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import styles from './LevelIcon.scss';
-import Image from 'react-bootstrap/lib/Image';
 
 const LevelIcon = ({level}) => {
   return level ?
-    <Image className={styles.levelIcon} src={require('../assets/graphics/level-' + level + '.svg')}
+    <img className={styles.levelIcon} src={require('../assets/graphics/level-' + level + '.svg')}
       alt={'Level' + level}
     />
     : null;

--- a/src/components/LevelIcon.js
+++ b/src/components/LevelIcon.js
@@ -6,7 +6,7 @@ import styles from './LevelIcon.scss';
 const LevelIcon = ({level}) => {
   return level ?
     <img className={styles.levelIcon} src={require('../assets/graphics/level-' + level + '.svg')}
-      alt={'Level' + level}
+      alt={'Level ' + level}
     />
     : null;
 };

--- a/src/components/Navigation/BreadCrumb.js
+++ b/src/components/Navigation/BreadCrumb.js
@@ -19,7 +19,7 @@ const BreadCrumb = ({params, title, level, courseIcon}) => {
   const isValidCourse = isCourse && isValidCoursePath(coursePath);
   const isValidLesson = isLesson && (isValidLessonPath(lessonPath) || isValidReadmePath(lessonPath));
 
-  const homeLink = <NavLink to='/' onlyActiveOnIndex>
+  const homeLink = <NavLink to='/' onlyActiveOnIndex aria-label={'Home'}>
     <Glyphicon glyph='home' className={styles.homeIcon}/>
   </NavLink>;
 

--- a/src/components/Navigation/BreadCrumb.js
+++ b/src/components/Navigation/BreadCrumb.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux';
 import NavLink from './NavLink';
 import LevelIcon from '../LevelIcon';
 import Glyphicon from 'react-bootstrap/lib/Glyphicon';
+import Image from 'react-bootstrap/lib/Image';
 import styles from './BreadCrumb.scss';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import {capitalize} from '../../util';
@@ -24,7 +25,7 @@ const BreadCrumb = ({params, title, level, courseIcon}) => {
   </NavLink>;
 
   const courseLink = <NavLink to={coursePath} className={styles.lessonLink}>
-    <img className={styles.courseIcon} src={courseIcon}/>
+    <Image className={styles.courseIcon} src={courseIcon} alt={course}/>
     <span className={styles.lesson}>{capitalize(course)}</span>
   </NavLink>;
 

--- a/src/components/Navigation/BreadCrumb.js
+++ b/src/components/Navigation/BreadCrumb.js
@@ -9,8 +9,9 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import {capitalize} from '../../util';
 import {getTitle, getLevel} from '../../selectors/frontmatter';
 import {getCourseIcon, isValidCoursePath, isValidLessonPath, isValidReadmePath} from '../../contexts';
+import {getTranslator} from '../../selectors/translate';
 
-const BreadCrumb = ({params, title, level, courseIcon}) => {
+const BreadCrumb = ({params, title, level, courseIcon, t}) => {
   const {course, lesson, file} = params;
   const isLesson = !!file;
   const isCourse = course && !isLesson;
@@ -19,7 +20,7 @@ const BreadCrumb = ({params, title, level, courseIcon}) => {
   const isValidCourse = isCourse && isValidCoursePath(coursePath);
   const isValidLesson = isLesson && (isValidLessonPath(lessonPath) || isValidReadmePath(lessonPath));
 
-  const homeLink = <NavLink to='/' onlyActiveOnIndex aria-label={'Home'}>
+  const homeLink = <NavLink to='/' onlyActiveOnIndex aria-label={t('general.home')}>
     <Glyphicon glyph='home' className={styles.homeIcon}/>
   </NavLink>;
 
@@ -54,12 +55,14 @@ BreadCrumb.propTypes = {
   title: PropTypes.string.isRequired,
   level: PropTypes.number.isRequired,
   courseIcon: PropTypes.string,
+  t: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state, {params}) => ({
   title: getTitle(state, params),
   level: getLevel(state, params),
   courseIcon: getCourseIcon(params.course),
+  t: getTranslator(state),
 });
 
 export default connect(

--- a/src/components/Navigation/BreadCrumb.js
+++ b/src/components/Navigation/BreadCrumb.js
@@ -4,7 +4,6 @@ import {connect} from 'react-redux';
 import NavLink from './NavLink';
 import LevelIcon from '../LevelIcon';
 import Glyphicon from 'react-bootstrap/lib/Glyphicon';
-import Image from 'react-bootstrap/lib/Image';
 import styles from './BreadCrumb.scss';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import {capitalize} from '../../util';
@@ -25,7 +24,7 @@ const BreadCrumb = ({params, title, level, courseIcon}) => {
   </NavLink>;
 
   const courseLink = <NavLink to={coursePath} className={styles.lessonLink}>
-    <Image className={styles.courseIcon} src={courseIcon} alt={course}/>
+    <img className={styles.courseIcon} src={courseIcon} alt={course}/>
     <span className={styles.lesson}>{capitalize(course)}</span>
   </NavLink>;
 

--- a/src/components/Navigation/Footer.js
+++ b/src/components/Navigation/Footer.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import Grid from 'react-bootstrap/lib/Grid';
 import Row from 'react-bootstrap/lib/Row';
+import Image from 'react-bootstrap/lib/Image';
 import {getTranslator} from '../../selectors/translate';
 import styles from './Footer.scss';
 
@@ -21,25 +22,39 @@ const Footer = ({t, isStudentMode}) => {
   const sponsors = (
     <Row className={styles.sponsors}>
       <a href={url.sparebank} target="_blank">
-        <img className={styles.img} src={require('../../assets/graphics/smn.jpg')}/>
+        <Image className={styles.img} src={require('../../assets/graphics/smn.jpg')}
+          alt='SpareBank1'
+        />
       </a>
       <a href={url.ibok} target="_blank">
-        <img className={styles.img} src={require('../../assets/graphics/ibok.jpg')}/>
+        <Image className={styles.img} src={require('../../assets/graphics/ibok.jpg')}
+          alt='Ibok'
+        />
       </a>
       <a href={url.teknograd} target="_blank">
-        <img className={styles.img} src={require('../../assets/graphics/teknograd.png')}/>
+        <Image className={styles.img} src={require('../../assets/graphics/teknograd.png')}
+          alt='Teknograd'
+        />
       </a>
       <a href={url.tekna} target="_blank">
-        <img className={styles.img} src={require('../../assets/graphics/tekna.jpg')} />
+        <Image className={styles.img} src={require('../../assets/graphics/tekna.jpg')}
+          alt='Tekna'
+        />
       </a>
       <a href={url.ntnu_idi} target="_blank">
-        <img className={styles.img} src={require('../../assets/graphics/ntnu_idi.png')}/>
+        <Image className={styles.img} src={require('../../assets/graphics/ntnu_idi.png')}
+          alt='NTNU institutt for datateknologi og informatikk'
+        />
       </a>
       <a href={url.excited} target="_blank">
-        <img className={styles.img} src={require('../../assets/graphics/excITEd.png')}/>
+        <Image className={styles.img} src={require('../../assets/graphics/excITEd.png')}
+          alt='excited'
+        />
       </a>
       <a href={url.uio_ifi} target="_blank">
-        <img className={styles.img} src={require('../../assets/graphics/uio_ifi.png')}/>
+        <Image className={styles.img} src={require('../../assets/graphics/uio_ifi.png')}
+          alt='UIO institutt for informatikk'
+        />
       </a>
     </Row>);
 
@@ -47,7 +62,9 @@ const Footer = ({t, isStudentMode}) => {
     <Grid fluid={true} className={isStudentMode ? styles.containerStudent : styles.containerTeacher}>
       <Row className={styles.githubIcon}>
         <a href={url.oppgaver} target="_blank">
-          <img className={styles.svg} src={require('../../assets/graphics/github.png')}/>
+          <Image className={styles.svg} src={require('../../assets/graphics/github.png')}
+            alt='GitHub'
+          />
         </a>
       </Row>
       <Row className={styles.contribute}>

--- a/src/components/Navigation/Footer.js
+++ b/src/components/Navigation/Footer.js
@@ -4,7 +4,6 @@ import {connect} from 'react-redux';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import Grid from 'react-bootstrap/lib/Grid';
 import Row from 'react-bootstrap/lib/Row';
-import Image from 'react-bootstrap/lib/Image';
 import {getTranslator} from '../../selectors/translate';
 import styles from './Footer.scss';
 
@@ -22,38 +21,38 @@ const Footer = ({t, isStudentMode}) => {
   const sponsors = (
     <Row className={styles.sponsors}>
       <a href={url.sparebank} target="_blank">
-        <Image className={styles.img} src={require('../../assets/graphics/smn.jpg')}
-          alt='SpareBank1'
+        <img className={styles.img} src={require('../../assets/graphics/smn.jpg')}
+          alt={'SpareBank1'}
         />
       </a>
       <a href={url.ibok} target="_blank">
-        <Image className={styles.img} src={require('../../assets/graphics/ibok.jpg')}
-          alt='Ibok'
+        <img className={styles.img} src={require('../../assets/graphics/ibok.jpg')}
+          alt={'Ibok'}
         />
       </a>
       <a href={url.teknograd} target="_blank">
-        <Image className={styles.img} src={require('../../assets/graphics/teknograd.png')}
-          alt='Teknograd'
+        <img className={styles.img} src={require('../../assets/graphics/teknograd.png')}
+          alt={'Teknograd'}
         />
       </a>
       <a href={url.tekna} target="_blank">
-        <Image className={styles.img} src={require('../../assets/graphics/tekna.jpg')}
-          alt='Tekna'
+        <img className={styles.img} src={require('../../assets/graphics/tekna.jpg')}
+          alt={'Tekna'}
         />
       </a>
       <a href={url.ntnu_idi} target="_blank">
-        <Image className={styles.img} src={require('../../assets/graphics/ntnu_idi.png')}
-          alt='NTNU institutt for datateknologi og informatikk'
+        <img className={styles.img} src={require('../../assets/graphics/ntnu_idi.png')}
+          alt={'NTNU institutt for datateknologi og informatikk'}
         />
       </a>
       <a href={url.excited} target="_blank">
-        <Image className={styles.img} src={require('../../assets/graphics/excITEd.png')}
-          alt='excited'
+        <img className={styles.img} src={require('../../assets/graphics/excITEd.png')}
+          alt={'excited'}
         />
       </a>
       <a href={url.uio_ifi} target="_blank">
-        <Image className={styles.img} src={require('../../assets/graphics/uio_ifi.png')}
-          alt='UIO institutt for informatikk'
+        <img className={styles.img} src={require('../../assets/graphics/uio_ifi.png')}
+          alt={'UIO institutt for informatikk'}
         />
       </a>
     </Row>);
@@ -62,8 +61,8 @@ const Footer = ({t, isStudentMode}) => {
     <Grid fluid={true} className={isStudentMode ? styles.containerStudent : styles.containerTeacher}>
       <Row className={styles.githubIcon}>
         <a href={url.oppgaver} target="_blank">
-          <Image className={styles.svg} src={require('../../assets/graphics/github.png')}
-            alt='GitHub'
+          <img className={styles.svg} src={require('../../assets/graphics/github.png')}
+            alt={'GitHub'}
           />
         </a>
       </Row>

--- a/src/components/Navigation/LanguageDropdown.js
+++ b/src/components/Navigation/LanguageDropdown.js
@@ -6,7 +6,6 @@ import {resetOneFilter} from '../../reducers/filter';
 import {collapseAllFilterGroups} from '../../reducers/filterGroupsCollapsed';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
-import Image from 'react-bootstrap/lib/Image';
 import DropdownButton from 'react-bootstrap/lib/DropdownButton';
 import {getAvailableLanguages} from '../../util';
 import styles from './LanguageDropdown.scss';
@@ -18,7 +17,7 @@ const LanguageItem = ({language, translateTag, onlyFlag}) => {
   // Note that the block with "float" (the flag) must be first in the containing div
   return (
     <div>
-      <Image className={styles.flag} src={require(`../../assets/graphics/flag_${language}.svg`)}
+      <img className={styles.flag} src={require(`../../assets/graphics/flag_${language}.svg`)}
         alt={translateTag('language', language)}
       />
       <span className={styles.language + (onlyFlag ? ' ' + styles.onlyFlag : '')}>

--- a/src/components/Navigation/LanguageDropdown.js
+++ b/src/components/Navigation/LanguageDropdown.js
@@ -6,6 +6,7 @@ import {resetOneFilter} from '../../reducers/filter';
 import {collapseAllFilterGroups} from '../../reducers/filterGroupsCollapsed';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
+import Image from 'react-bootstrap/lib/Image';
 import DropdownButton from 'react-bootstrap/lib/DropdownButton';
 import {getAvailableLanguages} from '../../util';
 import styles from './LanguageDropdown.scss';
@@ -17,7 +18,9 @@ const LanguageItem = ({language, translateTag, onlyFlag}) => {
   // Note that the block with "float" (the flag) must be first in the containing div
   return (
     <div>
-      <img className={styles.flag} src={require(`../../assets/graphics/flag_${language}.svg`)}/>
+      <Image className={styles.flag} src={require(`../../assets/graphics/flag_${language}.svg`)}
+        alt={translateTag('language', language)}
+      />
       <span className={styles.language + (onlyFlag ? ' ' + styles.onlyFlag : '')}>
         {translateTag('language', language)}
       </span>

--- a/src/components/Navigation/NavBar.js
+++ b/src/components/Navigation/NavBar.js
@@ -6,7 +6,7 @@ import styles from './NavBar.scss';
 import Navbar from 'react-bootstrap/lib/Navbar';
 import Nav from 'react-bootstrap/lib/Nav';
 import NavItem from 'react-bootstrap/lib/NavItem';
-//import FormControl from 'react-bootstrap/lib/FormControl';
+import Image from 'react-bootstrap/lib/Image';
 import Clearfix from 'react-bootstrap/lib/Clearfix';
 import LinkContainer from 'react-router-bootstrap/lib/LinkContainer';
 import {getTranslator} from '../../selectors/translate';
@@ -14,19 +14,10 @@ import BreadCrumb from './BreadCrumb';
 import LanguageDropdown from './LanguageDropdown';
 import ModeDropdown from './ModeDropdown';
 
-/*const SearchBox = ({t})  => {
-  return <FormControl type='text' placeholder={t('search.placeholder')}/>
-};
-
-SearchBox.propTypes = {
-  // mapStateToProps
-  t: PropTypes.func.isRequired
-};*/
-
 const LkkBrand = () => {
   return <Navbar.Brand>
     <a href="http://kidsakoder.no" className={styles.logo}>
-      <img src={require('../../assets/graphics/LKK_small.png')}/>
+      <Image src={require('../../assets/graphics/LKK_small.png')} alt='Logo'/>
     </a>
   </Navbar.Brand>;
 };

--- a/src/components/Navigation/NavBar.js
+++ b/src/components/Navigation/NavBar.js
@@ -16,7 +16,7 @@ import ModeDropdown from './ModeDropdown';
 const LkkBrand = () => {
   return <Navbar.Brand>
     <a href="http://kidsakoder.no" className={styles.logo}>
-      <img src={require('../../assets/graphics/LKK_small.png')} alt={'Logo'}/>
+      <img src={require('../../assets/graphics/LKK_small.png')} alt={'LKK logo'}/>
     </a>
   </Navbar.Brand>;
 };

--- a/src/components/Navigation/NavBar.js
+++ b/src/components/Navigation/NavBar.js
@@ -6,7 +6,6 @@ import styles from './NavBar.scss';
 import Navbar from 'react-bootstrap/lib/Navbar';
 import Nav from 'react-bootstrap/lib/Nav';
 import NavItem from 'react-bootstrap/lib/NavItem';
-import Image from 'react-bootstrap/lib/Image';
 import Clearfix from 'react-bootstrap/lib/Clearfix';
 import LinkContainer from 'react-router-bootstrap/lib/LinkContainer';
 import {getTranslator} from '../../selectors/translate';
@@ -17,7 +16,7 @@ import ModeDropdown from './ModeDropdown';
 const LkkBrand = () => {
   return <Navbar.Brand>
     <a href="http://kidsakoder.no" className={styles.logo}>
-      <Image src={require('../../assets/graphics/LKK_small.png')} alt='Logo'/>
+      <img src={require('../../assets/graphics/LKK_small.png')} alt={'Logo'}/>
     </a>
   </Navbar.Brand>;
 };

--- a/src/components/PdfHeader.js
+++ b/src/components/PdfHeader.js
@@ -5,12 +5,13 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import {capitalize} from '../util';
 import styles from './PdfHeader.scss';
 import {iconContext} from '../contexts';
+import Image from 'react-bootstrap/lib/Image';
 
 const PdfHeader = ({params, courseIcon}) => {
   const {course} = params;
   return (
     <div className={styles.container}>
-      <img className={styles.courseIcon} src={courseIcon}/>
+      <Image className={styles.courseIcon} src={courseIcon} alt={course}/>
       <span className={styles.course}>{capitalize(course)}</span>
     </div>
   );

--- a/src/components/PdfHeader.js
+++ b/src/components/PdfHeader.js
@@ -5,13 +5,12 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import {capitalize} from '../util';
 import styles from './PdfHeader.scss';
 import {iconContext} from '../contexts';
-import Image from 'react-bootstrap/lib/Image';
 
 const PdfHeader = ({params, courseIcon}) => {
   const {course} = params;
   return (
     <div className={styles.container}>
-      <Image className={styles.courseIcon} src={courseIcon} alt={course}/>
+      <img className={styles.courseIcon} src={courseIcon} alt={course}/>
       <span className={styles.course}>{capitalize(course)}</span>
     </div>
   );

--- a/src/components/PlaylistPage/LessonItem.js
+++ b/src/components/PlaylistPage/LessonItem.js
@@ -5,7 +5,6 @@ import LinkContainer from 'react-router-bootstrap/lib/LinkContainer';
 import styles from './LessonItem.scss';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import Glyphicon from 'react-bootstrap/lib/Glyphicon';
-import Image from 'react-bootstrap/lib/Image';
 import ListGroupItem from 'react-bootstrap/lib/ListGroupItem';
 import LevelIcon from '../LevelIcon';
 import {getTranslator, getTranslateTag} from '../../selectors/translate';
@@ -27,7 +26,7 @@ const LessonItem = ({lesson, isStudentMode, filterLanguage, language, t, tt, che
 
   const checkedExactlyOneLanguage = Object.values(filterLanguage).filter(value => value).length === 1;
   const flag = checkedExactlyOneLanguage && filterLanguage[language] ? null :
-    <Image className={styles.flag} src={require(`../../assets/graphics/flag_${lesson.language}.svg`)}
+    <img className={styles.flag} src={require(`../../assets/graphics/flag_${lesson.language}.svg`)}
       alt={tt('language', language)}
     />;
 

--- a/src/components/PlaylistPage/LessonItem.js
+++ b/src/components/PlaylistPage/LessonItem.js
@@ -5,15 +5,16 @@ import LinkContainer from 'react-router-bootstrap/lib/LinkContainer';
 import styles from './LessonItem.scss';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import Glyphicon from 'react-bootstrap/lib/Glyphicon';
+import Image from 'react-bootstrap/lib/Image';
 import ListGroupItem from 'react-bootstrap/lib/ListGroupItem';
 import LevelIcon from '../LevelIcon';
-import {getTranslator} from '../../selectors/translate';
+import {getTranslator, getTranslateTag} from '../../selectors/translate';
 import {getLessonIntro, createCheckboxesKey} from '../../util';
 import {getNumberOfCheckedCheckboxes, getTotalNumberOfCheckboxes} from '../../selectors/checkboxes';
 import PopoverComponent from '../PopoverComponent';
 import InstructionButton from '../InstructionButton';
 
-const LessonItem = ({lesson, isStudentMode, filterLanguage, language, t, checkedCheckboxes, totalCheckboxes}) => {
+const LessonItem = ({lesson, isStudentMode, filterLanguage, language, t, tt, checkedCheckboxes, totalCheckboxes}) => {
   const progressPercent = totalCheckboxes > 0 ? 100 * checkedCheckboxes / totalCheckboxes : 0;
   const progress = checkedCheckboxes > 0 ?
     <div className={styles.progress}>
@@ -26,7 +27,9 @@ const LessonItem = ({lesson, isStudentMode, filterLanguage, language, t, checked
 
   const checkedExactlyOneLanguage = Object.values(filterLanguage).filter(value => value).length === 1;
   const flag = checkedExactlyOneLanguage && filterLanguage[language] ? null :
-    <img className={styles.flag} src={require(`../../assets/graphics/flag_${lesson.language}.svg`)}/>;
+    <Image className={styles.flag} src={require(`../../assets/graphics/flag_${lesson.language}.svg`)}
+      alt={tt('language', language)}
+    />;
 
   const instructionButton = isStudentMode ? null :
     <InstructionButton
@@ -84,6 +87,7 @@ LessonItem.propTypes = {
   filterLanguage: PropTypes.objectOf(PropTypes.bool).isRequired,
   language: PropTypes.string.isRequired,
   t: PropTypes.func.isRequired,
+  tt: PropTypes.func.isRequired,
   checkedCheckboxes: PropTypes.number.isRequired,
   totalCheckboxes: PropTypes.number.isRequired,
 };
@@ -93,6 +97,7 @@ const mapStateToProps = (state, {lesson}) => ({
   filterLanguage: state.filter.language,
   language: state.language,
   t: getTranslator(state),
+  tt: getTranslateTag(state),
   checkedCheckboxes: getNumberOfCheckedCheckboxes(state, createCheckboxesKey(lesson.path)),
   totalCheckboxes: getTotalNumberOfCheckboxes(state, createCheckboxesKey(lesson.path)),
 });

--- a/src/constants/captions_da.js
+++ b/src/constants/captions_da.js
@@ -2,6 +2,7 @@ const softHyphen = '\u00ad';
 
 export default {
   general: {
+    home: 'Hjem',
     student: 'Elev',
     teacher: 'Lærer',
     level: 'Nivå',
@@ -41,7 +42,9 @@ export default {
               'og alle oppgavesett har veiledninger du kan sjekke ut som forberedelse til øktene. ' +
               'For nybegynnere så anbefaler vi blokkbasert programmering, hvor Python / Web / Processing ' +
               'er de vanligste å gå videre med etterpå.',
-      link2: 'Lær mer om å drive en kodeklubb'
+      link2: 'Lær mer om å drive en kodeklubb',
+      plus: 'Vis mer informasjon',
+      minus: 'Vis mindre informasjon'
     },
     showhidefilter: 'Vis/skjul filter'
   },

--- a/src/constants/captions_en.js
+++ b/src/constants/captions_en.js
@@ -1,5 +1,6 @@
 export default {
   general: {
+    home: 'Home',
     student: 'Student',
     teacher: 'Teacher',
     level: 'Level',
@@ -38,7 +39,9 @@ export default {
              'new this time. Now you can easily filter tasks on topics, and all assignments have instructions ' +
              'that you can check in preparation for the sessions. For beginners, we recommend block-based ' +
              'programming, where Python / Web / Processing is the most common to proceed with afterwards.',
-      link2: 'Learn more about running a code club'
+      link2: 'Learn more about running a code club',
+      plus: 'Show more information',
+      minus: 'Show less information'
     },
     showhidefilter: 'Show/hide filter',
     forumbutton: 'Go to forum'

--- a/src/constants/captions_nb.js
+++ b/src/constants/captions_nb.js
@@ -2,6 +2,7 @@ const softHyphen = '\u00ad';
 
 export default {
   general: {
+    home: 'Hjem',
     student: 'Elev',
     teacher: 'Lærer',
     level: 'Nivå',
@@ -41,7 +42,9 @@ export default {
               'og alle oppgavesett har veiledninger du kan sjekke ut som forberedelse til øktene. ' +
               'For nybegynnere så anbefaler vi blokkbasert programmering, hvor Python / Web / Processing ' +
               'er de vanligste å gå videre med etterpå.',
-      link2: 'Lær mer om å drive en kodeklubb'
+      link2: 'Lær mer om å drive en kodeklubb',
+      plus: 'Vis mer informasjon',
+      minus: 'Vis mindre informasjon'
     },
     showhidefilter: 'Vis/skjul filter'
   },

--- a/src/constants/captions_nn.js
+++ b/src/constants/captions_nn.js
@@ -2,6 +2,7 @@ const softHyphen = '\u00ad';
 
 export default {
   general: {
+    home: 'Heim',
     student: 'Elev',
     teacher: 'Lærar',
     level: 'Nivå',
@@ -41,7 +42,9 @@ export default {
               'og alle oppgåvesetta har rettleiingar du kan sjekke ut som førebuing til øyktene. ' +
               'For nybegynnarar anbefaler me blokkbasert programmering, der Python, Web eller Processing ' +
               'er dei vanlegaste å gå vidare med etterpå.',
-      link2: 'Lær meir om å drive ein kodeklubb'
+      link2: 'Lær meir om å drive ein kodeklubb',
+      plus: 'Vis meir informasjon',
+      minus: 'Vis mindre informasjon'
     },
     showhidefilter: 'Vis/skjul filter'
   },

--- a/src/constants/captions_sv.js
+++ b/src/constants/captions_sv.js
@@ -2,6 +2,7 @@ const softHyphen = '\u00ad';
 
 export default {
   general: {
+    home: 'Hjem',
     student: 'Elev',
     teacher: 'Lærer',
     level: 'Nivå',
@@ -41,7 +42,9 @@ export default {
               'og alle oppgavesett har veiledninger du kan sjekke ut som forberedelse til øktene. ' +
               'For nybegynnere så anbefaler vi blokkbasert programmering, hvor Python / Web / Processing ' +
               'er de vanligste å gå videre med etterpå.',
-      link2: 'Lær mer om å drive en kodeklubb'
+      link2: 'Lær mer om å drive en kodeklubb',
+      plus: 'Vis mer informasjon',
+      minus: 'Vis mindre informasjon'
     },
     showhidefilter: 'Vis/skjul filter'
   },

--- a/src/processContent.js
+++ b/src/processContent.js
@@ -57,7 +57,10 @@ const insertHeaderIcons = (obj) => {
         content: [
           {
             tag: 'img',
-            attrs: { src: icons[className] }
+            attrs: {
+              src: icons[className],
+              alt: className
+            }
           },
           ...obj.content
         ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -262,6 +262,13 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.7.1.tgz#26cbb5aff64144b0a825be1846e0b16cfa00b11e"
+  dependencies:
+    ast-types-flow "0.0.7"
+    commander "^2.11.0"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -379,6 +386,10 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
+ast-types-flow@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+
 ast-types@0.9.5:
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.5.tgz#1a660a09945dbceb1f9c9cbb715002617424e04a"
@@ -453,6 +464,12 @@ aws4@^1.2.1:
 aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
+
+axobject-query@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
+  dependencies:
+    ast-types-flow "0.0.7"
 
 babel-cli@^6.26.0:
   version "6.26.0"
@@ -2370,6 +2387,10 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
+damerau-levenshtein@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -2702,6 +2723,10 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+emoji-regex@^6.1.0:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -2876,6 +2901,18 @@ escope@^3.6.0:
     es6-weak-map "^2.0.1"
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
+
+eslint-plugin-jsx-a11y@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.3.tgz#54583d1ae442483162e040e13cc31865465100e5"
+  dependencies:
+    aria-query "^0.7.0"
+    array-includes "^3.0.3"
+    ast-types-flow "0.0.7"
+    axobject-query "^0.1.0"
+    damerau-levenshtein "^1.0.0"
+    emoji-regex "^6.1.0"
+    jsx-ast-utils "^2.0.0"
 
 eslint-plugin-react@^7.3.0:
   version "7.3.0"
@@ -4644,13 +4681,6 @@ js-yaml@^3.7.0:
   dependencies:
     argparse "^1.0.7"
     esprima "^3.1.1"
-
-js-yaml@^3.8.3:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
 
 js-yaml@~3.7.0:
   version "3.7.0"


### PR DESCRIPTION
Solves #465 for this repo. Rest has to be done at the oppgave repo.

img tags is now instead Image components from react-bootstrap. The alt attributes should maybe be a bit better than they are now?

Also added the jsx-a11y plugin for eslint with the recommended rules. This gave 3 more errors including the img alt error. That's why I changed FilterGroup.js, FilterItem.js and RadioButtons.js. This fix is just for the eslinter, but should be further fixed since this is not 100% correct...

