### PR TITLE
Issue 395 removed beta from link

### DIFF
--- a/src/components/Lesson/ImprovePage.js
+++ b/src/components/Lesson/ImprovePage.js
@@ -13,7 +13,7 @@ const ImprovePage = ({t, isStudentMode, courseLessonFileProp}) => {
   const linkToSourceCode = 'https://github.com/kodeklubben/oppgaver/tree/master/src/' +
                            courseName + '/' + lessonName;
 
-  const linkToLesson = 'http://oppgaver.kidsakoder.no/beta/' + //'/beta' should be removed when the site goes live
+  const linkToLesson = 'http://oppgaver.kidsakoder.no/' +
                        courseName + '/' + lessonName + '/' + lessonName;
 
   const newIssueFill = '?title=' + t('lessons.improvepage.newissuelink.title') + ' \'' +


### PR DESCRIPTION
Solves #395 

Since we will be releasing the new sites asap, there is no need to do more than just remove the beta from the link. And the link without beta will still show the same lesson, just on the old site