### PR TITLE
Remove markdown-it-anchor

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "isomorphic-style-loader": "^4.0.0",
     "jsdom": "^9.2.1",
     "json-loader": "^0.5.4",
-    "markdown-it-anchor": "^2.5.0",
     "markdown-it-attrs": "^0.5.1",
     "markdown-it-header-sections": "^0.2.2",
     "markdown-it-implicit-figures": "^0.3.0",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -36,7 +36,6 @@
 import webpack from 'webpack';
 import path from 'path';
 
-import MarkdownItAnchor from 'markdown-it-anchor';
 import MarkdownItAttrs from 'markdown-it-attrs';
 import MarkdownItHeaderSections from 'markdown-it-header-sections';
 import MarkdownItImplicitFigures from 'markdown-it-implicit-figures';
@@ -252,7 +251,6 @@ const createConfig = (env = {}) => {
               MarkdownItAttrs,
               MarkdownItHeaderSections,
               MarkdownItImplicitFigures,
-              MarkdownItAnchor,
               [MarkdownItTaskCheckbox, {disabled: false}],
             ],
             highlight,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5257,12 +5257,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-it-anchor@^2.5.0:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-2.7.1.tgz#372f67da7a4c4632ad0ebe4c9691726efe25342a"
-  dependencies:
-    string "^3.0.1"
-
 markdown-it-attrs@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/markdown-it-attrs/-/markdown-it-attrs-0.5.1.tgz#41e7b6cfe03ecd86fef29e84d3b6677089845704"
@@ -7975,10 +7969,6 @@ string-width@^2.1.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string@^3.0.1:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/string/-/string-3.3.3.tgz#5ea211cd92d228e184294990a6cc97b366a77cb0"
 
 string_decoder@^1.0.0, string_decoder@~1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Don't see any difference with this plugin, other than adding more of the same id's as the children. And this is a bad thing for accessibility