### PR TITLE
Remove pure_funcs in uglifyjsplugin (webpack)

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -296,7 +296,6 @@ const createConfig = (env = {}) => {
           sourceMap: true,
           compress: {
             warnings: false,
-            pure_funcs: 'console.log', // removes these functions from the code
           }
         }),
       ] : []),


### PR DESCRIPTION
For some reason, using pure_funcs=console.log in uglifyjs plugin webpack seems to break the site.