### PR TITLE
Fix pdf and tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A viewer to display codeclub lessons",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server -d --progress --inline --hot --history-api-fallback --host 0.0.0.0",
+    "start": "webpack-dev-server -d --progress --inline --hot --host 0.0.0.0",
     "build:debug": "webpack -d --progress --env.verbose",
     "build": "webpack --progress",
     "build:prod": "webpack -p --progress --env.NODE_ENV=production --env.BUILD_PDF",

--- a/src/components/LessonPage/PdfButton.js
+++ b/src/components/LessonPage/PdfButton.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
@@ -9,8 +11,9 @@ import Glyphicon from 'react-bootstrap/lib/Glyphicon';
 import {getLessonFrontmatter} from '../../resources/lessonFrontmatter';
 
 const PdfButton = ({course, lesson, language, isReadme, t}) => {
+  const {path} = getLessonFrontmatter(course, lesson, language, isReadme);
   const options = {
-    href: getLessonFrontmatter(course, lesson, language, isReadme).pdfPath,
+    href: `${process.env.PUBLICPATH}${path.slice(1)}.pdf`,
     bsStyle: 'pdf',
     bsSize: 'small',
     className: styles.container,

--- a/src/resources/courseFrontmatter.js
+++ b/src/resources/courseFrontmatter.js
@@ -50,7 +50,7 @@ const getData = memoize(
       const [/* ignore */, course, file] = key.match(/^[.][/]([^/]+)[/](index[^.]*)[.]md$/);
       const {title = '', external = '', language} = courseFrontmatterContext(key);
       if (getAvailableLanguages().includes(language)) {
-        const path = `/${course}/${file}`; // TODO: Add publicpath?
+        const path = `/${course}/${file}`;
         const data = {title, external, path, key};
         assignDeep(courses, [course, language], data);
       } else {

--- a/src/resources/lessonFrontmatter.js
+++ b/src/resources/lessonFrontmatter.js
@@ -24,7 +24,6 @@ const lessonFrontmatterContext =
  *           translator: 'Kari',
  *           external: 'https://www.example.com/external', // doesn't always exist
  *           path: '/scratch/astrokatt/astrokatt',
- *           pdfPath: '/scratch/astrokatt/astrokatt.pdf',
  *           key: './scratch/astrokatt/astrokatt.md',
  *         },
  *         1: {
@@ -33,7 +32,6 @@ const lessonFrontmatterContext =
  *           author: 'Gro',
  *           translator: 'Per',
  *           path: '/scratch/astrokatt/README_nn',
- *           pdfPath: '/scratch/astrokatt/README_nn.pdf',
  *           key: './scratch/astrokatt/README_nn.md',
  *         },
  *       },
@@ -63,9 +61,8 @@ const getData = memoize(
       if (!title) { console.warn('WARNING: The lesson', key, 'did not specify title.'); }
       if (language) {
         const isReadmeKey = file.startsWith('README') ? 1 : 0;
-        const path = `/${course}/${lesson}/${file}`; // TODO: Add publicpath?
-        const pdfPath = `${path}.pdf`;
-        const lessonData = {title, level, author, translator, external, path, pdfPath, key};
+        const path = `/${course}/${lesson}/${file}`;
+        const lessonData = {title, level, author, translator, external, path, key};
         assignDeep(lessons, [course, lesson, language, isReadmeKey], lessonData);
       } else {
         console.warn('WARNING: The lesson', key, 'did not specify language, so lesson will not be used.');

--- a/src/util.js
+++ b/src/util.js
@@ -117,7 +117,7 @@ export const extractFirstPartOfHtml = (html, path) => {
     // and <img src=astrokatt.png>
     picture = picture.replace(
       /( src="?)([^" />]*)([" />])/,
-      '$1' + process.env.PUBLICPATH_WITHOUT_SLASH + dirname(path).slice(1) + '/$2$3',
+      '$1' + process.env.PUBLICPATH + dirname(path).slice(1) + '/$2$3',
     );
   }
   return (picture || '') + (text || '');

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -348,7 +348,7 @@ const createConfig = (env = {}) => {
 
     devServer: {
       historyApiFallback: { // needed when using browserHistory (instead of hashHistory)
-        index: publicPath
+        index: `${publicPath}index.html`
       },
     },
   };


### PR DESCRIPTION
Fixes path to PDF.
Fixes path to images in lesson tooltips.

It also fixes the history-api-fallback when running `yarn start` if `url-path-prefix.config` contains `beta`, so that if you write `.../beta/scratch`, that actually works.