### PR TITLE
529 url ends with slash breaks

### DIFF
--- a/server.js
+++ b/server.js
@@ -31,10 +31,7 @@ app.get('*', function (req, res) {
     if (url === publicPathWithoutSlash || url === publicPathWithoutSlash + '/') {
       filepath = path.join(buildDir, 'index.html');
     } else {
-      filepath = path.join(buildBaseDir, url);
-      if (filepath.endsWith('/')) {
-        filepath = filepath + 'index.html';
-      }
+      filepath = path.join(buildBaseDir, url, url.endsWith('/') ? 'index.html' : '');
       if (new RegExp(`^(.*${slash}[^.${slash}]+)$`).test(filepath)) { // if urlpath has no extension...
         filepath = filepath + '.html';  // ... add .html extension
       }

--- a/server.js
+++ b/server.js
@@ -10,13 +10,14 @@ const { buildBaseDir, buildDir, publicPathWithoutSlash } = require('./buildconst
 
 // All RegExps that involve paths must have the path parts surrounded by regexpCompPath
 const regexpCompPath = (str) => path.normalize(str).replace(/\\/g, '\\\\');
+const slash = regexpCompPath('/');
 
 const app = express();
 app.use(compression());
 
 
 // serve our static stuff (i.e. urls that match files that exists)
-app.use(publicPathWithoutSlash, express.static(path.resolve(buildDir), {redirect: false}));
+app.use(publicPathWithoutSlash, express.static(path.normalize(buildDir), {redirect: false}));
 
 // send all requests other requests here
 app.get('*', function (req, res) {
@@ -28,18 +29,18 @@ app.get('*', function (req, res) {
   } else {
     let filepath;
     if (url === publicPathWithoutSlash || url === publicPathWithoutSlash + '/') {
-      filepath = path.resolve(buildDir, 'index.html');
+      filepath = path.join(buildDir, 'index.html');
     } else {
-      filepath = path.resolve(buildBaseDir, url.slice(1)); // Remove leading slash
-      if (filepath.endsWith(regexpCompPath('/'))) {
-        filepath = filepath.slice(0, -1);
-      } // Remove trailing slash if it exists
-      if (new RegExp('^(.*' + regexpCompPath('/') + '[^.]+)$').test(filepath)) { // if urlpath has no extension...
+      filepath = path.join(buildBaseDir, url);
+      if (filepath.endsWith('/')) {
+        filepath = filepath + 'index.html';
+      }
+      if (new RegExp(`^(.*${slash}[^.${slash}]+)$`).test(filepath)) { // if urlpath has no extension...
         filepath = filepath + '.html';  // ... add .html extension
       }
       if (!fs.existsSync(filepath)) { // if file doesn't exist, send to 404.html
         console.log('Could not find file at path', filepath);
-        filepath = path.resolve(buildDir, '404.html');
+        filepath = path.join(buildDir, '404.html');
       }
     }
     res.sendFile(filepath); // Otherwise serve file

--- a/src/routes.js
+++ b/src/routes.js
@@ -51,6 +51,20 @@ const rewritePath = (nextState, replace) => {
         ' when rendering static pages (' + nextpath + ')');
     }
   }
+  else if (nextpath !== '/' && nextpath.endsWith('/')) {
+    // Github pages looks for /.../index (or index.html) if url ends with slash,
+    // e.g if url is /scratch/ then github looks for /scratch/index (or /scratch/index.html)
+    // Since we don't have this index file (only /scratch.html), github pages serves 404.html.
+    // But, once the js has loaded, react router doesn't care about the last slash,
+    // so it renders the page anyway. But any relative urls in that page won't work, so the page is broken (looks bad).
+    // Thus we need to make sure that urls become what they are actually treated as.
+    if (typeof document !== 'undefined') {
+      replace(nextpath + 'index' + nextState.location.search);
+    } else {
+      console.error('The router cannot handle paths that end in /' +
+        ' when rendering static pages (' + nextpath + ')');
+    }
+  }
 };
 
 const appOnEnter = (nextState, replace) => {


### PR DESCRIPTION
Solves #529.

**UPDATE**: Note that instead of adding the redirect from `scratch/` to `scratch/index`, we could add two extra routes like so:
```
const routes =
  <Route path="/" component={App} onEnter={appOnEnter} onChange={appOnChange}>
    <IndexRoute component={FrontPage}/>
    <Route path="/:a/" component={PageNotFound}/>
    <Route path="/:course" getComponent={getCoursePage}/>
    <Route path="/:a/:b/:c/" component={PageNotFound}/>
    <Route path="/:course/:lesson/:file" getComponent={getLessonPage}/>
    <Route path="*" component={PageNotFound}/>
  </Route>;
```
This will make sure that paths ending in slash are routed to PageNotFound. Note that the params in the route cannot be `course`, `lesson`, and `file` since then the breadcrumb would pick up on them (unless we want that). Here I just used `a`, `b`, and `c`.

The difference between this solution and the one submitted, is that this one doesn't rewrite the url, i.e. it will stay `/scratch/astrokatt/astrokatt/`, while the one submitted will be rewritten to `/scratch/astrokatt/astrokatt/index`

@Skagevang : If you think this last solution is better, let me change it. I will update the comments as well to explain what is going on.

**UPDATE 2**: I we want the urls with the trailing slashes to work I can think of a way (or maybe two) to rewrite them correctly that would also work on github pages.

The first is to create index.html files with only a `<meta http-equiv="refresh" content="0; url=.." />` in the header (hoping that the `..` url will work). E.g. for the file `/scratch.html`, we would create a `/scratch/index.html` with the rewrite header, and for `/scratch/astrokatt/astrokatt_nn.html` we would create `/scratch/astrokatt/astrokatt_nn/index.html`.

The other solution to make the trailing slash urls to work, is to somehow make the 404.html-script do the redirect, but I am not quite sure how, since it would need some logic to check which urls to make the redirects for. Also, this solution might flash the "page not found" page before redirecting, so not ideal.

@Skagevang: My suggestion right now is to keep the current PR as it is (after a nights sleep I think it is better than the solution with the extra routes), and make another issue to add the index files with redirects if we want the trailing-slash-urls to work. 