### PR TITLE
Remove 2px of shadow below navbar

### DIFF
--- a/src/components/Navigation/NavBar.scss
+++ b/src/components/Navigation/NavBar.scss
@@ -136,7 +136,7 @@ $widget-height: 50px;
   min-height: $widget-height;
   font-weight: 300;
   border-radius: 0;
-  margin-bottom: -5px; // to get rid of the 5px spacing below, don't understand why it is there
+  margin-bottom: -7px; // to get rid of the 7px spacing below, don't understand why it is there
 }
 
 .widgetStudent {


### PR DESCRIPTION
Remove 2px of shadow below navbar. It used to be 5px. Not sure why it was 5px before, and not sure why it is 7px now.