### PR TITLE
Extra files, no copy of yml, only deploy for push to kodeklubben

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 stages:
   - name: deploy
-    if: branch = master AND type = push # AND fork = false
+    if: branch = master AND type = push AND fork = false
 
 before_install:
   - git clone --depth=1 --branch=master https://github.com/kodeklubben/oppgaver.git ../oppgaver

--- a/src/assets/deploy/README.md
+++ b/src/assets/deploy/README.md
@@ -1,0 +1,4 @@
+kodeklubben.github.io
+=====================
+
+Dette er filene for nettstedet <http://kodeklubben.github.io/> som inneholder [kodeklubbens oppgaver](//github.com/kodeklubben/oppgaver) som html. Dersom du ønsker å gjøre endringer til nettstedet må du gjøre endringen i [utgangspunktet som finnes her](//github.com/kodeklubben/oppgaver/), ettersom filene i dette repoet blir generert automatisk.

--- a/src/assets/deploy/google91a144a83c954edb.html
+++ b/src/assets/deploy/google91a144a83c954edb.html
@@ -1,0 +1,1 @@
+google-site-verification: google91a144a83c954edb.html

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -256,12 +256,18 @@ const createConfig = (env = {}) => {
         }
       }),
 
-      new CopyWebpackPlugin([{
-        context: lessonSrc,
-        from: lessonSrc + '/**/*',
-        ignore: '*.md',
-        to: buildDir + '/[path][name].[ext]'
-      }]),
+      new CopyWebpackPlugin([
+        { // Copy all resource files (i.e. all files not included via javascript)
+          context: lessonSrc,
+          from: lessonSrc + '/**/*',
+          ignore: ['*.md', '*.yml'],
+          to: buildDir + '/[path][name].[ext]'
+        },
+        { // Copy extra files that need to be included
+          from: './src/assets/deploy/',
+          to: buildDir
+        }
+      ]),
 
       new CaseSensitivePathsPlugin(),
 


### PR DESCRIPTION
Add extra files needed for deploy, and ignore yml-files as resources. Also, only deploy when pushing to non-fork (kodeklubben/codeclub-viewer).

It will still only deploy to norwegiankiwi/kodeklubben.github.io.