### PR TITLE
Automatic deploy to kodeklubben/kodeklubben.github.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ deploy:
   skip-cleanup: true
   keep-history: true
   local-dir: dist
-  repo: norwegiankiwi/kodeklubben.github.io
+  repo: kodeklubben/kodeklubben.github.io
   target-branch: master
   fqdn: oppgaver.kidsakoder.no
   on:


### PR DESCRIPTION
Deploy to kodeklubben/kodeklubben.github.io instead of norwegiankiwi/kodeklubben.github.io

When/if this PR is merged, anytime a merge is done into kodeklubben/codeclub-viewer's master branch, a new deploy will be made to kodeklubben/kodeklubben.github.io.

It has been tested a little bit first deploying to norwegiankiwi/kodeklubben.github.io, and that seems to work ok.

If this works fine, we can consider adding a similar script to merges on kodeklubben/oppgaver.