### PR TITLE
Add eslint-babel-plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,8 +15,13 @@
     },
     "sourceType": "module"
   },
-  "plugins": ["react", "jsx-a11y"],
+  "plugins": [
+    "react",
+    "jsx-a11y",
+    "babel"
+  ],
   "rules": {
+    "babel/semi": "error",
     "eol-last": ["error"],
     "indent": ["error", 2, {"SwitchCase": 1}],
     "quotes": ["error", "single", {"avoidEscape": true, "allowTemplateLiterals": true}],
@@ -24,10 +29,10 @@
     "max-len": ["error", 120],
     "no-console": ["off"], // we automatically strip console.log from production code, and we want to keep console.warn and console.error
     "no-unused-vars": ["error", { "vars": "all", "args": "none" }], // only warn of unused args and vars
-    "react/jsx-uses-vars": [1],      // avoid no-unused-vars for imports used as react components
-    "react/jsx-uses-react": [1],     // avoid no-unused-vars for importing React
+    "react/jsx-uses-vars": ["warn"],      // avoid no-unused-vars for imports used as react components
+    "react/jsx-uses-react": ["warn"],     // avoid no-unused-vars for importing React
     "react/jsx-no-bind": ["error"],
-    "react/react-in-jsx-scope": [1], // make sure React is in scope when writing jsx
+    "react/react-in-jsx-scope": ["warn"], // make sure React is in scope when writing jsx
     "no-var": ["error"],
     "jsx-a11y/label-has-for": [ "error", {
       "components": [ "Label" ],

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "deep-freeze": "^0.0.1",
     "ejs-compiled-loader": "^1.1.0",
     "eslint": "^4.6.1",
+    "eslint-plugin-babel": "^5.1.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.3.0",
     "express": "^4.16.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2940,6 +2940,12 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-plugin-babel@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-5.1.0.tgz#9c76e476162041e50b6ba69aa4eae3bdd6a4e1c3"
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
 eslint-plugin-jsx-a11y@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.3.tgz#54583d1ae442483162e040e13cc31865465100e5"
@@ -2960,6 +2966,10 @@ eslint-plugin-react@^7.3.0:
     has "^1.0.1"
     jsx-ast-utils "^2.0.0"
     prop-types "^15.5.10"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
 
 eslint-scope@^3.7.1, eslint-scope@~3.7.1:
   version "3.7.1"


### PR DESCRIPTION
Add eslint-babel-plugin and enable semi, to also catch missing semi-colons in class properties.