### PR TITLE
Refactor LessonPage ++

### DIFF
--- a/src/components/CoursePage/LessonItem.js
+++ b/src/components/CoursePage/LessonItem.js
@@ -10,7 +10,6 @@ import LevelIcon from '../LevelIcon';
 import PopoverComponent from '../PopoverComponent';
 import InstructionButton from '../InstructionButton';
 import Flag from '../Flag';
-import {createCheckboxesKey} from '../../utils/checkboxUtils';
 import {getLessonTitle, getLessonPath, getLessonExternal} from '../../resources/lessonFrontmatter';
 import {getLevel} from '../../resources/lessons';
 import {getLessonIntro} from '../../resources/lessonContent';
@@ -40,7 +39,6 @@ const LessonItem = ({
   lesson,
   language,
   title,
-  path,
   external,
   popoverContent,
   isStudentMode,
@@ -79,7 +77,7 @@ const LessonItem = ({
           </span>
         </ListGroupItem>
         :
-        <LinkContainer to={path}>
+        <LinkContainer to={getLessonPath(course, lesson, language, false)}>
           <ListGroupItem className={styles.row}>
             {flag}
             <Progressbar {...{checkedCheckboxes, totalCheckboxes, level}}/>
@@ -105,7 +103,6 @@ LessonItem.propTypes = {
 
   // mapStateToProps
   title: PropTypes.string.isRequired,
-  path: PropTypes.string.isRequired,
   external: PropTypes.string,
   popoverContent: PropTypes.string,
   isStudentMode: PropTypes.bool.isRequired,
@@ -115,20 +112,16 @@ LessonItem.propTypes = {
   totalCheckboxes: PropTypes.number.isRequired,
 };
 
-const mapStateToProps = (state, {course, lesson, language}) => {
-  const path = getLessonPath(course, lesson, language, false);
-  return {
-    title: getLessonTitle(course, lesson, language, false),
-    path,
-    external: getLessonExternal(course, lesson, language, false),
-    popoverContent: getLessonIntro(course, lesson, language, false),
-    isStudentMode: state.isStudentMode,
-    onlyCheckedMainLanguage: onlyCheckedMainLanguage(state),
-    t: getTranslator(state),
-    checkedCheckboxes: getNumberOfCheckedCheckboxes(state, createCheckboxesKey(path)),
-    totalCheckboxes: getTotalNumberOfCheckboxes(state, createCheckboxesKey(path)),
-  };
-};
+const mapStateToProps = (state, {course, lesson, language}) => ({
+  title: getLessonTitle(course, lesson, language, false),
+  external: getLessonExternal(course, lesson, language, false),
+  popoverContent: getLessonIntro(course, lesson, language, false),
+  isStudentMode: state.isStudentMode,
+  onlyCheckedMainLanguage: onlyCheckedMainLanguage(state),
+  t: getTranslator(state),
+  checkedCheckboxes: getNumberOfCheckedCheckboxes(state, course, lesson, language, false),
+  totalCheckboxes: getTotalNumberOfCheckboxes(state, course, lesson, language, false),
+});
 
 export default connect(
   mapStateToProps

--- a/src/components/LessonPage/Content.js
+++ b/src/components/LessonPage/Content.js
@@ -5,6 +5,10 @@ import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import styles from './Content.scss';
 import {processContent} from '../../utils/processContent';
 import {getLessonContent} from '../../resources/lessonContent';
+import {getLessonPath} from '../../resources/lessonFrontmatter';
+import {setCheckboxesInDoc} from '../../utils/checkboxUtils';
+import {setCheckbox, removeCheckbox} from '../../reducers/checkboxes';
+import {getCheckboxesForLesson} from '../../selectors/checkboxes';
 
 class Content extends React.PureComponent {
   createMarkup = () => {
@@ -12,6 +16,21 @@ class Content extends React.PureComponent {
     const lessonContent = getLessonContent(course, lesson, language, isReadme);
     return {__html: processContent(lessonContent, styles, isHydrated)};
   };
+
+  updateCheckboxes = () => {
+    const {course, lesson, language, isReadme, checkboxes, setCheckbox, removeCheckbox} = this.props;
+    const path = getLessonPath(course, lesson, language, isReadme);
+    setCheckboxesInDoc(path, checkboxes, setCheckbox, removeCheckbox);
+  };
+
+  componentDidMount() {
+    if (this.props.isHydrated) { this.updateCheckboxes(); } // When clicking in from different page
+  }
+
+  componentDidUpdate(prevProps) {
+    const wasHydratedThisUpdate = !prevProps.isHydrated && this.props.isHydrated;
+    if (wasHydratedThisUpdate) { this.updateCheckboxes(); } // When reloading page
+  }
 
   render() {
     return <div dangerouslySetInnerHTML={this.createMarkup()}/>;
@@ -27,12 +46,24 @@ Content.propTypes = {
 
   // mapStateToProps
   isHydrated: PropTypes.bool.isRequired, // require isHydrated as a prop to force rerender when it changes
+  checkboxes: PropTypes.object,
+
+  // mapDispatchToProps
+  setCheckbox: PropTypes.func.isRequired,
+  removeCheckbox: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state, {course, lesson, language, isReadme}) => ({
   isHydrated: state.hydration,
+  checkboxes: getCheckboxesForLesson(state, course, lesson, language, isReadme),
 });
+
+const mapDispatchToProps = {
+  setCheckbox,
+  removeCheckbox,
+};
 
 export default connect(
   mapStateToProps,
+  mapDispatchToProps,
 )(withStyles(styles)(Content));

--- a/src/components/LessonPage/Progress.js
+++ b/src/components/LessonPage/Progress.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import styles from './Progress.scss';
 import ProgressBar from 'react-bootstrap/lib/ProgressBar';
+import {getNumberOfCheckedCheckboxes, getTotalNumberOfCheckboxes} from '../../selectors/checkboxes';
 
-const Progress = ({checkedCheckboxes, totalCheckboxes}) => {
+const Progress = ({checkedCheckboxes, totalCheckboxes, isReadme}) => {
+  if (checkedCheckboxes <= 0 || isReadme) { return null; } 
   const now = totalCheckboxes > 0 ? 100 * checkedCheckboxes / totalCheckboxes : 0;
   const active = checkedCheckboxes < totalCheckboxes;
   const bsStyle = active ? 'danger' : 'success';
@@ -18,8 +21,21 @@ const Progress = ({checkedCheckboxes, totalCheckboxes}) => {
 
 Progress.propTypes = {
   // ownProps
+  course: PropTypes.string.isRequired,
+  lesson: PropTypes.string.isRequired,
+  language: PropTypes.string.isRequired,
+  isReadme: PropTypes.bool.isRequired,
+
+  // mapStateToProps
   checkedCheckboxes: PropTypes.number.isRequired,
   totalCheckboxes: PropTypes.number.isRequired,
 };
 
-export default withStyles(styles)(Progress);
+const mapStateToProps = (state, {course, lesson, language, isReadme}) => ({
+  checkedCheckboxes: getNumberOfCheckedCheckboxes(state, course, lesson, language, isReadme),
+  totalCheckboxes: getTotalNumberOfCheckboxes(state, course, lesson, language, isReadme),
+});
+
+export default connect(
+  mapStateToProps,
+)(withStyles(styles)(Progress));

--- a/src/selectors/checkboxes.js
+++ b/src/selectors/checkboxes.js
@@ -1,40 +1,54 @@
 import createCachedSelector from 're-reselect';
+import {getLessonPath} from '../resources/lessonFrontmatter';
+import {createCheckboxesKey} from '../utils/checkboxUtils';
 
-const getCheckboxesForPath = (state, lessonCheckboxesKey) => state.checkboxes[lessonCheckboxesKey] || {};
+const getKey = (course, lesson, language, isReadme) => 
+  createCheckboxesKey(getLessonPath(course, lesson, language, isReadme));
+
+export const getCheckboxesForLesson = (state, course, lesson, language, isReadme) => {
+  const checkboxesKey = getKey(course, lesson, language, isReadme);
+  return state.checkboxes[checkboxesKey] || {};
+};
 
 /**
  * Returns the number of checkboxes checked for given lesson
  * @param {object} state The redux state object
- * @param {string} lessonCheckboxesKey The key for lesson checkboxes
+ * @param {string} course E.g. 'scratch'
+ * @param {string} lesson E.g. 'astrokatt'
+ * @param {string} language E.g. 'nb'
+ * @param {boolean} isReadme
  * @returns {number} Number of checked checkboxes for a lesson
  */
 export const getNumberOfCheckedCheckboxes = createCachedSelector(
   // Input selectors:
-  getCheckboxesForPath,
+  getCheckboxesForLesson,
 
   // Output selector (resultfunc):
-  (checkboxesForPath) => Object.keys(checkboxesForPath).reduce(
-    (sum, hash) => sum + (checkboxesForPath[hash] ? 1 : 0),
+  (checkboxesForLesson) => Object.keys(checkboxesForLesson).reduce(
+    (sum, hash) => sum + (checkboxesForLesson[hash] ? 1 : 0),
     0
   )
 )(
   // Resolver function (same arguments as for input selectors). Returns selector cache key:
-  (state, lessonCheckboxesKey) => lessonCheckboxesKey
+  (state, course, lesson, language, isReadme) => getKey(course, lesson, language, isReadme)
 );
 
 /**
  * Returns total number of checkboxes for a lesson
  * @param {object} state The redux state object
- * @param {string} lessonCheckboxesKey The key for lesson checkboxes
+ * @param {string} course E.g. 'scratch'
+ * @param {string} lesson E.g. 'astrokatt'
+ * @param {string} language E.g. 'nb'
+ * @param {boolean} isReadme
  * @returns {number} Total number of checkboxes for a lesson
  */
 export const getTotalNumberOfCheckboxes = createCachedSelector(
   // Input selectors:
-  getCheckboxesForPath,
+  getCheckboxesForLesson,
 
   // Output selector (resultfunc):
-  (checkboxesForPath) => Object.keys(checkboxesForPath).length
+  (checkboxesForLesson) => Object.keys(checkboxesForLesson).length
 )(
   // Resolver function (same arguments as for input selectors). Returns selector cache key:
-  (state, lessonCheckboxesKey) => lessonCheckboxesKey
+  (state, course, lesson, language, isReadme) => getKey(course, lesson, language, isReadme)
 );

--- a/test/reducers/checkboxes_spec.js
+++ b/test/reducers/checkboxes_spec.js
@@ -1,0 +1,182 @@
+import {expect} from 'chai';
+import deepFreeze from 'deep-freeze';
+
+import reducer, {setCheckbox, removeCheckbox, setCheckboxes} from '../../src/reducers/checkboxes';
+
+describe('checkboxes reducer', () => {
+  describe('SET_CHECKBOX', () => {
+    it('when no checkboxes exist in state', () => {
+      const initialState = {};
+      const action = setCheckbox('path/to/lesson', '1234', true);
+      deepFreeze(initialState);
+      deepFreeze(action);
+      const nextState = reducer(initialState, action);
+      const expectedState = {
+        'checkboxes_path/to/lesson': {
+          '1234': true,
+        }
+      };
+      expect(nextState).to.deep.equal(expectedState);
+    });
+
+    it('when checkbox was previously set to false', () => {
+      const initialState = {
+        'checkboxes_path/to/lesson': {
+          '1234': false,
+          '5678': true,
+        }
+      };
+      const action = setCheckbox('path/to/lesson', '1234', true);
+      deepFreeze(initialState);
+      deepFreeze(action);
+      const nextState = reducer(initialState, action);
+      const expectedState = {
+        'checkboxes_path/to/lesson': {
+          '1234': true,
+          '5678': true,
+        }
+      };
+      expect(nextState).to.deep.equal(expectedState);
+    });
+
+    it('when checkbox was previously set to true', () => {
+      const initialState = {
+        'checkboxes_path/to/lesson': {
+          '1234': false,
+          '5678': true,
+        }
+      };
+      const action = setCheckbox('path/to/lesson', '5678', false);
+      deepFreeze(initialState);
+      deepFreeze(action);
+      const nextState = reducer(initialState, action);
+      const expectedState = {
+        'checkboxes_path/to/lesson': {
+          '1234': false,
+          '5678': false,
+        }
+      };
+      expect(nextState).to.deep.equal(expectedState);
+    });
+  });
+
+  describe('REMOVE_CHECKBOX', () => {
+    it('when path does not exist in state', () => {
+      const initialState = {};
+      const action = removeCheckbox('path/to/lesson', '1234');
+      deepFreeze(initialState);
+      deepFreeze(action);
+      const nextState = reducer(initialState, action);
+      const expectedState = {
+        'checkboxes_path/to/lesson': {}
+      };
+      expect(nextState).to.deep.equal(expectedState);
+    });
+
+    it('when path exists but checkbox does not exist in state', () => {
+      const initialState = {
+        'checkboxes_path/to/lesson': {
+          '1234': false,
+          '5678': false,
+        }
+      };
+      const action = removeCheckbox('path/to/lesson', '9999');
+      deepFreeze(initialState);
+      deepFreeze(action);
+      const nextState = reducer(initialState, action);
+      const expectedState = initialState;
+      expect(nextState).to.deep.equal(expectedState);
+    });
+
+    it('when checkbox was previously set to false', () => {
+      const initialState = {
+        'checkboxes_path/to/lesson': {
+          '1234': false,
+          '5678': true,
+        }
+      };
+      const action = removeCheckbox('path/to/lesson', '1234');
+      deepFreeze(initialState);
+      deepFreeze(action);
+      const nextState = reducer(initialState, action);
+      const expectedState = {
+        'checkboxes_path/to/lesson': {
+          '5678': true,
+        }
+      };
+      expect(nextState).to.deep.equal(expectedState);
+    });
+    
+    it('when checkbox was previously set to true', () => {
+      const initialState = {
+        'checkboxes_path/to/lesson': {
+          '1234': false,
+          '5678': true,
+        }
+      };
+      const action = removeCheckbox('path/to/lesson', '5678');
+      deepFreeze(initialState);
+      deepFreeze(action);
+      const nextState = reducer(initialState, action);
+      const expectedState = {
+        'checkboxes_path/to/lesson': {
+          '1234': false,
+        }
+      };
+      expect(nextState).to.deep.equal(expectedState);
+    });
+  });
+
+  describe('SET_CHECKBOXES', () => {
+    it('when no checkboxes exist in state', () => {
+      const initialState = {};
+      const checkboxes = {
+        '1234': false,
+        '5678': true,
+      };
+      const action = setCheckboxes('path/to/lesson', checkboxes);
+      deepFreeze(initialState);
+      deepFreeze(action);
+      const nextState = reducer(initialState, action);
+      const expectedState = {
+        'checkboxes_path/to/lesson': {
+          '1234': false,
+          '5678': true,
+        }
+      };
+      expect(nextState).to.deep.equal(expectedState);
+    });
+
+    it('when checkboxes exist for given path', () => {
+      const initialState = {
+        'checkboxes_path/to/lesson': {
+          '1234': false,
+          '5678': true,
+        },
+        'checkboxes_path/to/lesson2': {
+          '2222': true,
+          '3333': false,
+        },
+      };
+      const checkboxes = {
+        '7777': true,
+        '8888': false,
+      };
+      const action = setCheckboxes('path/to/lesson', checkboxes);
+      deepFreeze(initialState);
+      deepFreeze(action);
+      const nextState = reducer(initialState, action);
+      const expectedState = {
+        'checkboxes_path/to/lesson': {
+          '7777': true,
+          '8888': false,
+        },
+        'checkboxes_path/to/lesson2': {
+          '2222': true,
+          '3333': false,
+        },
+      };
+      expect(nextState).to.deep.equal(expectedState);
+    });
+  });
+});

--- a/test/selectors/checkboxes_spec.js
+++ b/test/selectors/checkboxes_spec.js
@@ -3,21 +3,21 @@ import deepFreeze from 'deep-freeze';
 
 import {getNumberOfCheckedCheckboxes, getTotalNumberOfCheckboxes} from '../../src/selectors/checkboxes';
 
-const checkboxesForPath_empty = deepFreeze({});
+const checkboxesForLesson_empty = deepFreeze({});
 
-const checkboxesForPath_zeroChecked = deepFreeze({
+const checkboxesForLesson_zeroChecked = deepFreeze({
   104227806: false,
   858451434: false,
   1317817857: false,
 });
 
-const checkboxesForPath_twoChecked = deepFreeze({
+const checkboxesForLesson_twoChecked = deepFreeze({
   104227806: true,
   858451434: false,
   1317817857: true,
 });
 
-const checkboxesForPath_threeChecked = deepFreeze({
+const checkboxesForLesson_threeChecked = deepFreeze({
   104227806: true,
   858451434: true,
   1317817857: true,
@@ -28,19 +28,19 @@ describe('selectors for checkboxes', () => {
   describe('getNumberOfCheckedCheckboxes', () => {
 
     it('should return zero when there are no checkboxes', () => {
-      expect(getNumberOfCheckedCheckboxes.resultFunc(checkboxesForPath_empty)).to.equal(0);
+      expect(getNumberOfCheckedCheckboxes.resultFunc(checkboxesForLesson_empty)).to.equal(0);
     });
 
     it('should return zero when 0 of 3 checkboxes are checked', () => {
-      expect(getNumberOfCheckedCheckboxes.resultFunc(checkboxesForPath_zeroChecked)).to.equal(0);
+      expect(getNumberOfCheckedCheckboxes.resultFunc(checkboxesForLesson_zeroChecked)).to.equal(0);
     });
 
     it('should return two when 2 of 3 checkboxes are checked', () => {
-      expect(getNumberOfCheckedCheckboxes.resultFunc(checkboxesForPath_twoChecked)).to.equal(2);
+      expect(getNumberOfCheckedCheckboxes.resultFunc(checkboxesForLesson_twoChecked)).to.equal(2);
     });
 
     it('should return three when 3 of 3 checkboxes are checked', () => {
-      expect(getNumberOfCheckedCheckboxes.resultFunc(checkboxesForPath_threeChecked)).to.equal(3);
+      expect(getNumberOfCheckedCheckboxes.resultFunc(checkboxesForLesson_threeChecked)).to.equal(3);
     });
 
   });
@@ -48,19 +48,19 @@ describe('selectors for checkboxes', () => {
   describe('getTotalNumberOfCheckboxes', () => {
 
     it('Should return zero when there are no checkboxes', () => {
-      expect(getTotalNumberOfCheckboxes.resultFunc(checkboxesForPath_empty)).to.equal(0);
+      expect(getTotalNumberOfCheckboxes.resultFunc(checkboxesForLesson_empty)).to.equal(0);
     });
 
     it('should return three when 0 of 3 checkboxes are checked', () => {
-      expect(getTotalNumberOfCheckboxes.resultFunc(checkboxesForPath_zeroChecked)).to.equal(3);
+      expect(getTotalNumberOfCheckboxes.resultFunc(checkboxesForLesson_zeroChecked)).to.equal(3);
     });
 
     it('should return three when 2 of 3 checkboxes are checked', () => {
-      expect(getTotalNumberOfCheckboxes.resultFunc(checkboxesForPath_twoChecked)).to.equal(3);
+      expect(getTotalNumberOfCheckboxes.resultFunc(checkboxesForLesson_twoChecked)).to.equal(3);
     });
 
     it('should return three when 3 of 3 checkboxes are checked', () => {
-      expect(getTotalNumberOfCheckboxes.resultFunc(checkboxesForPath_threeChecked)).to.equal(3);
+      expect(getTotalNumberOfCheckboxes.resultFunc(checkboxesForLesson_threeChecked)).to.equal(3);
     });
 
   });


### PR DESCRIPTION
Note that in Content, we now only update checkboxes once after it is hydrated, not each time (like it was done in LessonPage before).

In addition, moved stuff into pages where they belong.