### PR TITLE
654: Fix filter checkboxes

### DIFF
--- a/src/components/LessonPage/Content.js
+++ b/src/components/LessonPage/Content.js
@@ -42,7 +42,7 @@ const Content = ({course, lesson, language, isReadme}) => {
   if (course === 'scratch' && typeof document !== 'undefined' && isHydrated) {
     lessonContent = renderScratchBlocks(lessonContent, styles);
   }
-  return <div dangerouslySetInnerHTML={{__html: lessonContent}}/>;
+  return <div className={styles.lessonContent} dangerouslySetInnerHTML={{__html: lessonContent}}/>;
 };
 
 Content.propTypes = {

--- a/src/components/LessonPage/Content.scss
+++ b/src/components/LessonPage/Content.scss
@@ -41,25 +41,6 @@ $checkbox-blue: #abdbea;
   }
 }
 
-.check,
-.activity,
-.save {
-  @include styledList;
-}
-
-// scratch code blocks
-pre.blocks,
-code.b {
-  background-color: inherit;
-  border: 0;
-}
-
-// code blocks
-pre > code {
-  // override hljs background
-  background-color: transparent;
-}
-
 @mixin headingStyle {
   color: #fff;
   background: #349946;
@@ -67,242 +48,264 @@ pre > code {
   border-radius: 5px;
 }
 
-// sections
-section.activity {
-  // activities, "Step 1: Bla bla"
-  h1 {
-    @include headingStyle;
-  }
-  .subsection h2 {
+.lessonContent {
+
+  .check,
+  .activity,
+  .save {
     @include styledList;
-    @include headingStyle;
-    font-weight: 300;
   }
-}
 
-section.check {
-  // check lists
-  h2 {
-    padding-top: 4px;
-    padding-bottom: 9px;
-
-    img {
-      height: 40px;
-      vertical-align: text-bottom;
-      padding-right: 10px;
-    }
+  // scratch code blocks
+  pre.blocks,
+  code.b {
+    background-color: inherit;
+    border: 0;
   }
-}
 
-section.try {
-  background: #abdbea;
-  border-radius: 10px;
-  padding: 1px 20px 10px;
-  code {
-    background-color: #fff;
-    color: #007cc9;
-  }
-  li::before {
-    border: 3px solid #fff;
-  }
-}
-
-section.protip,
-section.tip {
-  border: 3px solid #ff7f00;
-  background: #fff99d;
-  border-radius: 12px;
-  padding: 0 20px 20px;
-  margin-top: 20px;
-  margin-bottom: 20px;
-}
-
-section.flag {
-  border-top: 3px dotted rgb(230, 134, 45);
-  padding-bottom: 20px;
-  margin-top: 20px;
-  margin-bottom: 20px;
-  h2 {
-    color: rgb(54, 161, 55);
-    margin-top: 10px;
-    margin-bottom: 10px;
-    padding-top: 15px;
-    padding-bottom: 10px;
-
-    img {
-      height: 40px;
-      vertical-align: text-bottom;
-      padding-right: 10px;
-    }
-  }
-}
-
-section.save {
-  border-top: 3px solid rgb(36, 90, 154);
-  margin: 20px 0;
-  h2 {
-    color: rgb(36, 90, 154);
-    margin: 0;
-    padding-top: 10px;
-    padding-bottom: 20px;
-
-    img {
-      height: 40px;
-      vertical-align: text-bottom;
-      padding-right: 10px;
-    }
-  }
-}
-
-section.challenge {
-  border: 3px solid #00b1da;
-  border-radius: 12px;
-  padding-bottom: 10px;
-  margin-top: 20px;
-  margin-bottom: 20px;
-  h2 {
-    color: #fff;
-    background: #00b1da;
-    padding-left: 20px;
-    padding-top: 10px;
-    padding-bottom: 10px;
-    margin-top: 0;
-
-    @media print {
-      border-bottom: 2px #00b1da solid;
-    }
-  }
-  > * {
-    padding: 0 20px;
-  }
-}
-
-// manual colors for scratch and microbit code
-// example: Press `motion`{.blockmotion} ...
-code {
-  &.blockmotion { background-color: #4c97ff; }
-  &.blocklooks { background-color: #96f; }
-  &.blocksound { background-color: #cf63cf; }
-  &.blockpen { background-color: #0fbd8c; }
-  &.blockdata { background-color: #ff8c1a; }
-  &.blockevents { background-color: #ffbf00; }
-  &.blockcontrol { background-color: #ffab19; }
-  &.blocksensing { background-color: #5cb1d6; }
-  &.blockoperators { background-color: #59c059; }
-  &.blockmoreblocks { background-color: #ff6680; }
-
-  &.microbitbasic { background-color: #1e90ff; }
-  &.microbitinput { background-color: #d400d4; }
-  &.microbitmusic { background-color: #e63022; }
-  &.microbitled { background-color: #5c2d91; }
-  &.microbitradio { background-color: #e3008c; }
-  &.microbitloops { background-color: #0a0; }
-  &.microbitlogic { background-color: #00a4a6; }
-  &.microbitvariables { background-color: #dc143c; }
-  &.microbitmath { background-color: #9400d3; }
-  &.microbitfunctions { background-color: #3455db; }
-  &.microbitarrays { background-color: #e65722; }
-  &.microbittext { background-color: #b8860b; }
-  &.microbitgame { background-color: #007a4b; }
-  &.microbitimages { background-color: #7600a8; }
-  &.microbitpins { background-color: #b22222; }
-  &.microbitserial { background-color: #002050; }
-  &.microbitcontrol { background-color: #333; }
-
-  &.blockmotion,
-  &.blocklooks,
-  &.blocksound,
-  &.blockpen,
-  &.blockdata,
-  &.blockevents,
-  &.blockcontrol,
-  &.blocksensing,
-  &.blockoperators,
-  &.blockmoreblocks,
-  &.microbitbasic,
-  &.microbitinput,
-  &.microbitmusic,
-  &.microbitled,
-  &.microbitradio,
-  &.microbitloops,
-  &.microbitlogic,
-  &.microbitvariables,
-  &.microbitmath,
-  &.microbitfunctions,
-  &.microbitarrays,
-  &.microbittext,
-  &.microbitgame,
-  &.microbitimages,
-  &.microbitpins,
-  &.microbitserial,
-  &.microbitcontrol {
-    color: #fff;
-  }
-}
-
-//// tables
-table {
-  // add table class to all tables, assumes that tables are only used
-  // for listing stuff and is not in use for other components like calendars
-  @extend .table;
-}
-
-// horisontal scroll on screens, do not wrap
-// not keyword negate _whole_ media query,
-// making `(not print) and (min-width: @screen-sm)` impossible
-@media aural, braille, handheld, projection, screen, tty, tv, embossed {
+  // code blocks
   pre > code {
-    word-wrap: normal;
-    white-space: pre;
+    // override hljs background
+    background-color: transparent;
   }
-}
 
-// embedded videos
-.video-container {
-  position: relative;
-  padding-bottom: 56.25%; // 16:9
-  height: 0;
-  overflow: hidden;
-  margin: 30px 0 60px;
-  iframe {
+  // sections
+  section.activity {
+    // activities, "Step 1: Bla bla"
+    h1 {
+      @include headingStyle;
+    }
+    .subsection h2 {
+      @include styledList;
+      @include headingStyle;
+      font-weight: 300;
+    }
+  }
+
+  section.check {
+    // check lists
+    h2 {
+      padding-top: 4px;
+      padding-bottom: 9px;
+
+      img {
+        height: 40px;
+        vertical-align: text-bottom;
+        padding-right: 10px;
+      }
+    }
+  }
+
+  section.try {
+    background: #abdbea;
+    border-radius: 10px;
+    padding: 1px 20px 10px;
+    code {
+      background-color: #fff;
+      color: #007cc9;
+    }
+    li::before {
+      border: 3px solid #fff;
+    }
+  }
+
+  section.protip,
+  section.tip {
+    border: 3px solid #ff7f00;
+    background: #fff99d;
+    border-radius: 12px;
+    padding: 0 20px 20px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+
+  section.flag {
+    border-top: 3px dotted rgb(230, 134, 45);
+    padding-bottom: 20px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+    h2 {
+      color: rgb(54, 161, 55);
+      margin-top: 10px;
+      margin-bottom: 10px;
+      padding-top: 15px;
+      padding-bottom: 10px;
+
+      img {
+        height: 40px;
+        vertical-align: text-bottom;
+        padding-right: 10px;
+      }
+    }
+  }
+
+  section.save {
+    border-top: 3px solid rgb(36, 90, 154);
+    margin: 20px 0;
+    h2 {
+      color: rgb(36, 90, 154);
+      margin: 0;
+      padding-top: 10px;
+      padding-bottom: 20px;
+
+      img {
+        height: 40px;
+        vertical-align: text-bottom;
+        padding-right: 10px;
+      }
+    }
+  }
+
+  section.challenge {
+    border: 3px solid #00b1da;
+    border-radius: 12px;
+    padding-bottom: 10px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+    h2 {
+      color: #fff;
+      background: #00b1da;
+      padding-left: 20px;
+      padding-top: 10px;
+      padding-bottom: 10px;
+      margin-top: 0;
+
+      @media print {
+        border-bottom: 2px #00b1da solid;
+      }
+    }
+    > * {
+      padding: 0 20px;
+    }
+  }
+
+  // manual colors for scratch and microbit code
+  // example: Press `motion`{.blockmotion} ...
+  code {
+    &.blockmotion { background-color: #4c97ff; }
+    &.blocklooks { background-color: #96f; }
+    &.blocksound { background-color: #cf63cf; }
+    &.blockpen { background-color: #0fbd8c; }
+    &.blockdata { background-color: #ff8c1a; }
+    &.blockevents { background-color: #ffbf00; }
+    &.blockcontrol { background-color: #ffab19; }
+    &.blocksensing { background-color: #5cb1d6; }
+    &.blockoperators { background-color: #59c059; }
+    &.blockmoreblocks { background-color: #ff6680; }
+
+    &.microbitbasic { background-color: #1e90ff; }
+    &.microbitinput { background-color: #d400d4; }
+    &.microbitmusic { background-color: #e63022; }
+    &.microbitled { background-color: #5c2d91; }
+    &.microbitradio { background-color: #e3008c; }
+    &.microbitloops { background-color: #0a0; }
+    &.microbitlogic { background-color: #00a4a6; }
+    &.microbitvariables { background-color: #dc143c; }
+    &.microbitmath { background-color: #9400d3; }
+    &.microbitfunctions { background-color: #3455db; }
+    &.microbitarrays { background-color: #e65722; }
+    &.microbittext { background-color: #b8860b; }
+    &.microbitgame { background-color: #007a4b; }
+    &.microbitimages { background-color: #7600a8; }
+    &.microbitpins { background-color: #b22222; }
+    &.microbitserial { background-color: #002050; }
+    &.microbitcontrol { background-color: #333; }
+
+    &.blockmotion,
+    &.blocklooks,
+    &.blocksound,
+    &.blockpen,
+    &.blockdata,
+    &.blockevents,
+    &.blockcontrol,
+    &.blocksensing,
+    &.blockoperators,
+    &.blockmoreblocks,
+    &.microbitbasic,
+    &.microbitinput,
+    &.microbitmusic,
+    &.microbitled,
+    &.microbitradio,
+    &.microbitloops,
+    &.microbitlogic,
+    &.microbitvariables,
+    &.microbitmath,
+    &.microbitfunctions,
+    &.microbitarrays,
+    &.microbittext,
+    &.microbitgame,
+    &.microbitimages,
+    &.microbitpins,
+    &.microbitserial,
+    &.microbitcontrol {
+      color: #fff;
+    }
+  }
+
+  //// tables
+  table {
+    // add table class to all tables, assumes that tables are only used
+    // for listing stuff and is not in use for other components like calendars
+    @extend .table;
+  }
+
+  // horisontal scroll on screens, do not wrap
+  // not keyword negate _whole_ media query,
+  // making `(not print) and (min-width: @screen-sm)` impossible
+  @media aural, braille, handheld, projection, screen, tty, tv, embossed {
+    pre > code {
+      word-wrap: normal;
+      white-space: pre;
+    }
+  }
+
+  // embedded videos
+  .video-container {
+    position: relative;
+    padding-bottom: 56.25%; // 16:9
+    height: 0;
+    overflow: hidden;
+    margin: 30px 0 60px;
+    iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  input[type="checkbox"] {
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    opacity: 0;
   }
-}
 
-input[type="checkbox"] {
-  position: absolute;
-  opacity: 0;
-}
+  input[type="checkbox"] + label {
+    position: relative;
+    font-weight: normal;
+    margin-left: 0;
+  }
 
-input[type="checkbox"] + label {
-  position: relative;
-  font-weight: normal;
-  margin-left: 0;
-}
+  input[type="checkbox"] + label::before {
+    content: '\a0'; // non-breaking space
+    display: inline-block;
+    visibility: visible;
+    width: 1.3em;
+    height: 1.3em;
+    margin: 0 0.6em 0 -2.2em;
+    line-height: 1.1em;
+    border: 3px solid $checkbox-blue;
+    border-radius: 3px;
+  }
 
-input[type="checkbox"] + label::before {
-  content: '\a0'; // non-breaking space
-  display: inline-block;
-  visibility: visible;
-  width: 1.3em;
-  height: 1.3em;
-  margin: 0 0.6em 0 -2.2em;
-  line-height: 1.1em;
-  border: 3px solid $checkbox-blue;
-  border-radius: 3px;
-}
+  input[type="checkbox"]:checked + label::before {
+    content: '\2714'; // checkmark
+    line-height: 1.1em;
+    padding-left: 0.1em;
+  }
 
-input[type="checkbox"]:checked + label::before {
-  content: '\2714'; // checkmark
-  line-height: 1.1em;
-  padding-left: 0.1em;
-}
-
-input[type="checkbox"]:active + label::before,
-input[type="checkbox"]:focus + label::before {
-  background: darken($checkbox-blue, 20%);
+  input[type="checkbox"]:active + label::before,
+  input[type="checkbox"]:focus + label::before {
+    background: darken($checkbox-blue, 20%);
+  }
 }


### PR DESCRIPTION
This PR fixes the problem in issue #654 that checkboxes disappear from filter after visiting a lesson.

The fix is to wrap css for lesson content in classname `.lessonContent` and apply this to the content div.

Note that this might be a symptom that the styles are not being applied correctly. In theory, the css from the lesson page should be removed when moving back to front page or course page.

Tip: When reviewing this, select "Hide whitespace changes"