### PR TITLE
Override bootstrap print stylesheet to restore color decorations in print

### DIFF
--- a/src/components/LessonPage/Content.scss
+++ b/src/components/LessonPage/Content.scss
@@ -199,9 +199,8 @@ $checkbox-blue: #abdbea;
     &.microbitmusic { background-color: #e63022 !important; }
     &.microbitled { background-color: #5c2d91 !important; }
     &.microbitradio { background-color: #e3008c !important; }
-    &.microbitradio { background-color: #e3008c !important; }
     &.microbitloops { background-color: #0a0 !important; }
-    &.microbitlogic { background-color: #00a4a6  !important; }
+    &.microbitlogic { background-color: #00a4a6 !important; }
     &.microbitvariables { background-color: #dc143c !important; }
     &.microbitmath { background-color: #9400d3 !important; }
     &.microbitfunctions { background-color: #3455db !important; }

--- a/src/components/LessonPage/Content.scss
+++ b/src/components/LessonPage/Content.scss
@@ -180,36 +180,38 @@ $checkbox-blue: #abdbea;
   }
 
   // manual colors for scratch and microbit code
-  // example: Press `motion`{.blockmotion} ...
+  // example: Press `motion`{.blockmotion} ...  They must be !important
+  // to override the bootstrap print style sheet
   code {
-    &.blockmotion { background-color: #4c97ff; }
-    &.blocklooks { background-color: #96f; }
-    &.blocksound { background-color: #cf63cf; }
-    &.blockpen { background-color: #0fbd8c; }
-    &.blockdata { background-color: #ff8c1a; }
-    &.blockevents { background-color: #ffbf00; }
-    &.blockcontrol { background-color: #ffab19; }
-    &.blocksensing { background-color: #5cb1d6; }
-    &.blockoperators { background-color: #59c059; }
-    &.blockmoreblocks { background-color: #ff6680; }
+    &.blockmotion { background-color: #4c97ff !important; }
+    &.blocklooks { background-color: #96f !important; }
+    &.blocksound { background-color: #cf63cf !important; }
+    &.blockpen { background-color: #0fbd8c !important; }
+    &.blockdata { background-color: #ff8c1a !important; }
+    &.blockevents { background-color: #ffbf00 !important; }
+    &.blockcontrol { background-color: #ffab19 !important; }
+    &.blocksensing { background-color: #5cb1d6 !important; }
+    &.blockoperators { background-color: #59c059 !important; }
+    &.blockmoreblocks { background-color: #ff6680 !important; }
 
-    &.microbitbasic { background-color: #1e90ff; }
-    &.microbitinput { background-color: #d400d4; }
-    &.microbitmusic { background-color: #e63022; }
-    &.microbitled { background-color: #5c2d91; }
-    &.microbitradio { background-color: #e3008c; }
-    &.microbitloops { background-color: #0a0; }
-    &.microbitlogic { background-color: #00a4a6; }
-    &.microbitvariables { background-color: #dc143c; }
-    &.microbitmath { background-color: #9400d3; }
-    &.microbitfunctions { background-color: #3455db; }
-    &.microbitarrays { background-color: #e65722; }
-    &.microbittext { background-color: #b8860b; }
-    &.microbitgame { background-color: #007a4b; }
-    &.microbitimages { background-color: #7600a8; }
-    &.microbitpins { background-color: #b22222; }
-    &.microbitserial { background-color: #002050; }
-    &.microbitcontrol { background-color: #333; }
+    &.microbitbasic { background-color: #1e90ff !important; }
+    &.microbitinput { background-color: #d400d4 !important; }
+    &.microbitmusic { background-color: #e63022 !important; }
+    &.microbitled { background-color: #5c2d91 !important; }
+    &.microbitradio { background-color: #e3008c !important; }
+    &.microbitradio { background-color: #e3008c !important; }
+    &.microbitloops { background-color: #0a0 !important; }
+    &.microbitlogic { background-color: #00a4a6  !important; }
+    &.microbitvariables { background-color: #dc143c !important; }
+    &.microbitmath { background-color: #9400d3 !important; }
+    &.microbitfunctions { background-color: #3455db !important; }
+    &.microbitarrays { background-color: #e65722 !important; }
+    &.microbittext { background-color: #b8860b !important; }
+    &.microbitgame { background-color: #007a4b !important; }
+    &.microbitimages { background-color: #7600a8 !important; }
+    &.microbitpins { background-color: #b22222 !important; }
+    &.microbitserial { background-color: #002050 !important; }
+    &.microbitcontrol { background-color: #333 !important; }
 
     &.blockmotion,
     &.blocklooks,


### PR DESCRIPTION
Se #688 - here is a PR to fix that.